### PR TITLE
feat: transcrição de audio para responder agora audios

### DIFF
--- a/src/adapters/BaileysAdapter.js
+++ b/src/adapters/BaileysAdapter.js
@@ -138,7 +138,8 @@ export class BaileysAdapter {
       msg?.extendedTextMessage?.contextInfo ||
       msg?.imageMessage?.contextInfo ||
       msg?.videoMessage?.contextInfo ||
-      msg?.stickerMessage?.contextInfo;
+      msg?.stickerMessage?.contextInfo ||
+      msg?.audioMessage?.contextInfo;
 
     return context?.quotedMessage;
   }
@@ -154,6 +155,50 @@ export class BaileysAdapter {
       q.videoMessage?.caption ||
       null
     );
+  }
+
+  // --- Detecção de Áudio ---
+
+  /**
+   * Verifica se a mensagem atual contém um áudio (PTT ou arquivo de áudio).
+   */
+  get hasAudio() {
+    const msg = this.innerMessage;
+    return !!(msg?.audioMessage);
+  }
+
+  /**
+   * Verifica se a mensagem citada (quoted) contém um áudio.
+   * Essa é a condição principal do fluxo de transcrição:
+   * usuário responde a um áudio mencionando a Luma.
+   */
+  get quotedHasAudio() {
+    const q = this.quotedMessage;
+    if (!q) return false;
+    const unwrapped = BaileysAdapter.unwrapMessage(q);
+    return !!(unwrapped?.audioMessage || q?.audioMessage);
+  }
+
+  /**
+   * Retorna o mimeType do áudio citado, necessário para a transcrição.
+   */
+  get quotedAudioMimeType() {
+    const q = this.quotedMessage;
+    if (!q) return "audio/ogg; codecs=opus";
+    const unwrapped = BaileysAdapter.unwrapMessage(q);
+    return (
+      unwrapped?.audioMessage?.mimetype ||
+      q?.audioMessage?.mimetype ||
+      "audio/ogg; codecs=opus"
+    );
+  }
+
+  /**
+   * Retorna o mimeType do áudio da mensagem atual.
+   */
+  get audioMimeType() {
+    const msg = this.innerMessage;
+    return msg?.audioMessage?.mimetype || "audio/ogg; codecs=opus";
   }
 
   // --- Métodos de Envio ---
@@ -264,7 +309,8 @@ export class BaileysAdapter {
       msg?.extendedTextMessage?.contextInfo ||
       msg?.imageMessage?.contextInfo ||
       msg?.videoMessage?.contextInfo ||
-      msg?.stickerMessage?.contextInfo;
+      msg?.stickerMessage?.contextInfo ||
+      msg?.audioMessage?.contextInfo;
 
     const fakeMsg = {
       key: {

--- a/src/services/AudioTranscriber.js
+++ b/src/services/AudioTranscriber.js
@@ -1,0 +1,127 @@
+import { GoogleGenAI } from "@google/genai";
+import { Logger } from "../utils/Logger.js";
+import { LUMA_CONFIG } from "../config/lumaConfig.js";
+
+/**
+ * Serviço de transcrição de áudios via Gemini.
+ * É acionado apenas quando o usuário cita/menciona a Luma
+ * respondendo a uma mensagem de áudio — evitando processamento desnecessário.
+ */
+export class AudioTranscriber {
+  constructor(apiKey) {
+    if (!apiKey) {
+      throw new Error("AudioTranscriber: API Key não fornecida.");
+    }
+    this.client = new GoogleGenAI({ apiKey });
+    this.models = LUMA_CONFIG.TECHNICAL.models;
+  }
+
+  /**
+   * Transcreve um buffer de áudio para texto usando o Gemini multimodal.
+   * Tenta os modelos em sequência (fallback automático).
+   *
+   * @param {Buffer} audioBuffer - Buffer do arquivo de áudio
+   * @param {string} mimeType - Tipo MIME do áudio (ex: "audio/ogg; codecs=opus")
+   * @returns {Promise<string|null>} Texto transcrito ou null em caso de falha
+   */
+  async transcribe(audioBuffer, mimeType = "audio/ogg; codecs=opus") {
+    const base64Audio = audioBuffer.toString("base64");
+
+    const normalizedMime = this._normalizeMimeType(mimeType);
+
+    const contents = [
+      {
+        role: "user",
+        parts: [
+          {
+            inlineData: {
+              data: base64Audio,
+              mimeType: normalizedMime,
+            },
+          },
+          {
+            text: `Transcreva exatamente o que foi dito neste áudio para texto.
+Retorne APENAS a transcrição literal, sem comentários, sem prefixos como "Transcrição:" ou aspas.
+Se o áudio for ininteligível ou apenas ruído, retorne exatamente: [áudio ininteligível]
+Se o áudio estiver vazio ou silencioso, retorne exatamente: [áudio sem conteúdo]`,
+          },
+        ],
+      },
+    ];
+
+    let lastError = null;
+
+    for (const model of this.models) {
+      try {
+        Logger.info(`🎙️ AudioTranscriber: Transcrevendo com ${model}...`);
+
+        const response = await this.client.models.generateContent({
+          model,
+          contents,
+          config: {
+            temperature: 0.1, // Baixa temperatura para maior fidelidade na transcrição
+            maxOutputTokens: 1024,
+          },
+        });
+
+        const text = this._extractText(response);
+
+        if (text) {
+          Logger.info(`✅ Áudio transcrito com sucesso (${text.length} chars)`);
+          return text.trim();
+        }
+
+        lastError = new Error("Resposta vazia do modelo");
+        continue;
+      } catch (error) {
+        lastError = error;
+        Logger.warn(
+          `⚠️ AudioTranscriber: Falha no modelo ${model}: ${error.message}`,
+        );
+        continue;
+      }
+    }
+
+    Logger.error("❌ AudioTranscriber: Todos os modelos falharam.", lastError);
+    return null;
+  }
+
+  /**
+   * Normaliza o mimeType do WhatsApp para um formato aceito pelo Gemini.
+   * O Baileys retorna "audio/ogg; codecs=opus" mas o Gemini aceita "audio/ogg".
+   */
+  _normalizeMimeType(mimeType) {
+    if (!mimeType) return "audio/ogg";
+
+    // Remove parâmetros extras como "; codecs=opus"
+    const base = mimeType.split(";")[0].trim().toLowerCase();
+
+    // Mapeamento de tipos comuns enviados pelo WhatsApp
+    const mimeMap = {
+      "audio/ogg": "audio/ogg",
+      "audio/mpeg": "audio/mp3",
+      "audio/mp4": "audio/mp4",
+      "audio/aac": "audio/aac",
+      "audio/wav": "audio/wav",
+      "audio/webm": "audio/webm",
+    };
+
+    return mimeMap[base] || "audio/ogg";
+  }
+
+  _extractText(response) {
+    const parts = response.candidates?.[0]?.content?.parts;
+    if (parts) {
+      return parts
+        .filter((p) => p.text)
+        .map((p) => p.text)
+        .join("");
+    }
+
+    try {
+      return response.text || "";
+    } catch {
+      return "";
+    }
+  }
+}


### PR DESCRIPTION
Testa antes de fazer o merge:

Acionada quando o usuário cita um áudio e menciona a Luma (ou está no privado). O BaileysAdapter detecta quotedHasAudio, o MessageHandler intercepta o fluxo antes dos handlers normais, baixa o buffer via MediaProcessor.downloadMedia, transcreve via AudioTranscriber (base64 + Gemini com temperature: 0.1) e injeta o texto transcrito no pipeline da Luma como contexto enriquecido — mantendo personalidade e histórico intactos. A transcrição é exibida ao usuário antes da resposta para transparência.