### PR TITLE
feat(phase-1): ports & adapters — fundação da arquitetura hexagonal

### DIFF
--- a/src/adapters/ai/GeminiAdapter.js
+++ b/src/adapters/ai/GeminiAdapter.js
@@ -1,0 +1,211 @@
+import { GoogleGenAI } from "@google/genai";
+import { AIPort } from "../../core/ports/AIPort.js";
+import { Logger } from "../../utils/Logger.js";
+import { LUMA_CONFIG } from "../../config/lumaConfig.js";
+
+/**
+ * Implementação de AIPort para o Google Gemini.
+ * Encapsula toda a lógica de comunicação com @google/genai,
+ * incluindo fallback automático entre modelos e o loop multi-turn de busca.
+ */
+export class GeminiAdapter extends AIPort {
+  /**
+   * @param {object} options
+   * @param {string} options.apiKey - Chave da API do Google Gemini
+   * @param {Array<string>} [options.models] - Modelos em ordem de prioridade (com fallback)
+   * @param {object} [options.genConfig] - Configurações de geração (temperature, tokens, etc.)
+   * @param {Array} [options.tools] - Definições de ferramentas (tool calling)
+   */
+  constructor({ apiKey, models, genConfig, tools } = {}) {
+    super();
+
+    if (!apiKey) throw new Error("GeminiAdapter: apiKey é obrigatória.");
+
+    this.client = new GoogleGenAI({ apiKey });
+    this.models = models ?? LUMA_CONFIG.TECHNICAL.models;
+    this.genConfig = genConfig ?? LUMA_CONFIG.TECHNICAL.generationConfig;
+    this.tools = tools ?? LUMA_CONFIG.TOOLS;
+    this._stats = this._initStats();
+  }
+
+  _initStats() {
+    const stats = new Map();
+    this.models.forEach((model) => {
+      stats.set(model, { successes: 0, failures: 0, lastUsed: null, lastError: null });
+    });
+    return stats;
+  }
+
+  /**
+   * Envia conteúdo ao Gemini com fallback automático entre modelos.
+   * Trata o loop multi-turn de busca (search_web tool call) internamente.
+   *
+   * @param {Array} contents - Array de mensagens no formato { role, parts } do @google/genai
+   * @returns {Promise<{text: string, functionCalls: Array}>}
+   */
+  async generateContent(contents) {
+    let lastError = null;
+
+    for (const model of this.models) {
+      const stat = this._stats.get(model);
+
+      try {
+        Logger.info(`🤖 GeminiAdapter: tentando modelo ${model}...`);
+        const response = await this._callModel(model, contents);
+        const result = this._extractFromResponse(response);
+
+        const searchCall = result.functionCalls.find((fc) => fc.name === "search_web");
+        if (searchCall) {
+          const final = await this._handleSearchTurn(model, contents, response, result, searchCall);
+          stat.successes++;
+          stat.lastUsed = new Date().toISOString();
+          stat.lastError = null;
+          return final;
+        }
+
+        stat.successes++;
+        stat.lastUsed = new Date().toISOString();
+        stat.lastError = null;
+        return result;
+      } catch (error) {
+        stat.failures++;
+        stat.lastError = error.message;
+        lastError = error;
+        this._logError(model, error);
+      }
+    }
+
+    throw new Error(`GeminiAdapter: todos os modelos falharam. Último erro: ${lastError?.message}`);
+  }
+
+  /** @returns {Array<{model, successes, failures, lastError}>} */
+  getStats() {
+    return Array.from(this._stats.entries()).map(([model, data]) => ({
+      model,
+      successes: data.successes,
+      failures: data.failures,
+      lastError: data.lastError,
+    }));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Privados
+  // ---------------------------------------------------------------------------
+
+  /** @private */
+  async _callModel(model, contents) {
+    return await this.client.models.generateContent({
+      model,
+      contents,
+      config: {
+        tools: this.tools,
+        temperature: this.genConfig.temperature,
+        maxOutputTokens: this.genConfig.maxOutputTokens,
+        topP: this.genConfig.topP,
+        topK: this.genConfig.topK,
+        safetySettings: [
+          { category: "HARM_CATEGORY_HATE_SPEECH",        threshold: "BLOCK_NONE" },
+          { category: "HARM_CATEGORY_HARASSMENT",          threshold: "BLOCK_NONE" },
+          { category: "HARM_CATEGORY_SEXUALLY_EXPLICIT",   threshold: "BLOCK_NONE" },
+          { category: "HARM_CATEGORY_DANGEROUS_CONTENT",   threshold: "BLOCK_NONE" },
+        ],
+      },
+    });
+  }
+
+  /**
+   * Executa o loop multi-turn de busca:
+   * 1. Chama SearchPort (injetado externamente, se disponível) com a query
+   * 2. Reenvia os resultados ao modelo como functionResponse
+   * 3. Retorna a resposta final gerada a partir dos resultados
+   * @private
+   */
+  async _handleSearchTurn(model, originalContents, modelResponse, firstResult, searchCall) {
+    try {
+      const query = searchCall.args?.query || "";
+      Logger.info(`🔍 GeminiAdapter buscando: "${query}"`);
+
+      // Usa o SearchPort injetado se disponível, senão usa Google Grounding como fallback interno
+      let searchResults;
+      if (this._searchPort) {
+        searchResults = await this._searchPort.search(query);
+      } else {
+        // Fallback interno: Google Search Grounding via o próprio cliente Gemini
+        const { GoogleGroundingAdapter } = await import("../search/GoogleGroundingAdapter.js");
+        const grounding = new GoogleGroundingAdapter({ client: this.client, model });
+        searchResults = await grounding.search(query);
+      }
+
+      const modelContent = modelResponse.candidates?.[0]?.content;
+      const followUpContents = [
+        ...originalContents,
+        modelContent,
+        {
+          role: "user",
+          parts: [{
+            functionResponse: {
+              name: "search_web",
+              response: { result: searchResults },
+            },
+          }],
+        },
+      ];
+
+      const followUpResponse = await this._callModel(model, followUpContents);
+      const finalResult = this._extractFromResponse(followUpResponse);
+
+      const otherCalls = firstResult.functionCalls.filter((fc) => fc.name !== "search_web");
+      finalResult.functionCalls = [...otherCalls, ...finalResult.functionCalls];
+
+      return finalResult;
+    } catch (error) {
+      Logger.error(`❌ GeminiAdapter: erro no turno de busca: ${error.message}`);
+      return {
+        text: firstResult.text,
+        functionCalls: firstResult.functionCalls.filter((fc) => fc.name !== "search_web"),
+      };
+    }
+  }
+
+  /** @private */
+  _extractFromResponse(response) {
+    let text = "";
+    let functionCalls = [];
+
+    const parts = response.candidates?.[0]?.content?.parts;
+
+    if (parts) {
+      for (const part of parts) {
+        if (part.text) text += part.text;
+        if (part.functionCall) functionCalls.push(part.functionCall);
+      }
+    } else {
+      try { if (response.text) text = response.text; } catch (_) {}
+      try {
+        if (Array.isArray(response.functionCalls)) functionCalls = response.functionCalls;
+      } catch (_) {}
+    }
+
+    return { text, functionCalls };
+  }
+
+  /** @private */
+  _logError(model, error) {
+    if (error.message?.includes("404") || error.message?.includes("not found")) {
+      Logger.warn(`❌ GeminiAdapter: modelo ${model} indisponível.`);
+    } else if (error.message?.includes("429") || error.status === 429) {
+      Logger.warn(`⚠️ GeminiAdapter: rate limit no ${model}, trocando...`);
+    } else {
+      Logger.error(`❌ GeminiAdapter: erro no ${model}: ${error.message}`);
+    }
+  }
+
+  /**
+   * Injeta um SearchPort para resolver buscas sem criar acoplamento circular.
+   * Chamado pelo Bootstrap/Container após criar o adapter.
+   * @param {import('../../core/ports/SearchPort.js').SearchPort} searchPort
+   */
+  setSearchPort(searchPort) {
+    this._searchPort = searchPort;
+  }
+}

--- a/src/adapters/search/GoogleGroundingAdapter.js
+++ b/src/adapters/search/GoogleGroundingAdapter.js
@@ -1,0 +1,58 @@
+import { SearchPort } from "../../core/ports/SearchPort.js";
+import { Logger } from "../../utils/Logger.js";
+
+/**
+ * Implementação de SearchPort usando Google Search Grounding via API do Gemini.
+ * Funciona como fallback quando o Tavily está indisponível ou como provider principal
+ * quando nenhuma chave Tavily é configurada.
+ */
+export class GoogleGroundingAdapter extends SearchPort {
+  /**
+   * @param {object} options
+   * @param {object} options.client - Instância de GoogleGenAI (do @google/genai)
+   * @param {string} options.model - Modelo Gemini a usar para a busca com grounding
+   */
+  constructor({ client, model } = {}) {
+    super();
+
+    if (!client) throw new Error("GoogleGroundingAdapter: client (GoogleGenAI) é obrigatório.");
+
+    this.client = client;
+    this.model = model ?? "gemini-2.0-flash";
+  }
+
+  /**
+   * Realiza uma busca usando Google Search Grounding via Gemini.
+   * O modelo recebe a ferramenta googleSearch e retorna resultados reais da web.
+   *
+   * @param {string} query
+   * @returns {Promise<string>}
+   */
+  async search(query) {
+    try {
+      Logger.info(`🌐 GoogleGroundingAdapter: buscando "${query}"`);
+
+      const response = await this.client.models.generateContent({
+        model: this.model,
+        contents: [{
+          role: "user",
+          parts: [{
+            text: `Pesquise na internet e forneça informações atualizadas sobre: ${query}\n\nResuma os resultados de forma objetiva em português.`,
+          }],
+        }],
+        config: {
+          tools: [{ googleSearch: {} }],
+          maxOutputTokens: 1024,
+        },
+      });
+
+      const parts = response.candidates?.[0]?.content?.parts ?? [];
+      const text = parts.map((p) => p.text ?? "").join("").trim();
+
+      return text || "Nenhum resultado encontrado.";
+    } catch (error) {
+      Logger.error(`❌ GoogleGroundingAdapter: falhou: ${error.message}`);
+      return "Não foi possível buscar informações no momento.";
+    }
+  }
+}

--- a/src/adapters/search/TavilyAdapter.js
+++ b/src/adapters/search/TavilyAdapter.js
@@ -1,0 +1,105 @@
+import { SearchPort } from "../../core/ports/SearchPort.js";
+import { Logger } from "../../utils/Logger.js";
+
+/**
+ * Implementação de SearchPort usando a API do Tavily.
+ * Quando a cota do Tavily é atingida (429), delega para um adapter de fallback
+ * injetado no construtor (tipicamente GoogleGroundingAdapter).
+ */
+export class TavilyAdapter extends SearchPort {
+  /**
+   * @param {object} options
+   * @param {string} options.apiKey - Chave da API do Tavily
+   * @param {SearchPort} [options.fallback] - Adapter de fallback quando a cota é atingida
+   */
+  constructor({ apiKey, fallback = null } = {}) {
+    super();
+
+    if (!apiKey) throw new Error("TavilyAdapter: apiKey é obrigatória.");
+
+    this.apiKey = apiKey;
+    this.fallback = fallback;
+    this._quotaExceeded = false;
+  }
+
+  /**
+   * Busca no Tavily. Faz fallback automático quando a cota é excedida.
+   * @param {string} query
+   * @returns {Promise<string>}
+   */
+  async search(query) {
+    if (!this._quotaExceeded) {
+      try {
+        const result = await this._searchTavily(query);
+        Logger.info("🔍 TavilyAdapter: busca concluída.");
+        return result;
+      } catch (error) {
+        if (this._isQuotaError(error)) {
+          this._quotaExceeded = true;
+          Logger.warn("⚠️ TavilyAdapter: cota esgotada — usando fallback.");
+        } else {
+          Logger.error(`❌ TavilyAdapter: falhou (${error.message}), usando fallback.`);
+        }
+      }
+    }
+
+    if (this.fallback) {
+      return await this.fallback.search(query);
+    }
+
+    return "Não foi possível buscar informações no momento.";
+  }
+
+  /** @private */
+  async _searchTavily(query) {
+    const response = await fetch("https://api.tavily.com/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_key: this.apiKey,
+        query,
+        search_depth: "basic",
+        max_results: 5,
+        include_answer: true,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(`HTTP ${response.status}: ${body}`);
+    }
+
+    const data = await response.json();
+    if (data.error) throw new Error(data.error);
+
+    return this._formatResults(data);
+  }
+
+  /** @private */
+  _formatResults(data) {
+    const lines = [];
+
+    if (data.answer) {
+      lines.push(`Resumo: ${data.answer}`, "");
+    }
+
+    (data.results || []).slice(0, 4).forEach((r, i) => {
+      lines.push(`[${i + 1}] ${r.title}`);
+      if (r.content) lines.push(r.content.substring(0, 350));
+      lines.push("");
+    });
+
+    return lines.join("\n").trim() || "Nenhum resultado encontrado.";
+  }
+
+  /** @private */
+  _isQuotaError(error) {
+    const msg = error.message?.toLowerCase() ?? "";
+    return msg.includes("429") || msg.includes("quota") || msg.includes("limit");
+  }
+
+  /** Reseta o estado de quota excedida (útil para testes). */
+  resetQuota() {
+    this._quotaExceeded = false;
+  }
+}

--- a/src/adapters/transcriber/GeminiTranscriberAdapter.js
+++ b/src/adapters/transcriber/GeminiTranscriberAdapter.js
@@ -1,0 +1,116 @@
+import { GoogleGenAI } from "@google/genai";
+import { TranscriberPort } from "../../core/ports/TranscriberPort.js";
+import { Logger } from "../../utils/Logger.js";
+import { LUMA_CONFIG } from "../../config/lumaConfig.js";
+
+/**
+ * Implementação de TranscriberPort usando o Gemini multimodal.
+ * Tenta múltiplos modelos em sequência (fallback automático).
+ */
+export class GeminiTranscriberAdapter extends TranscriberPort {
+  /**
+   * @param {object} options
+   * @param {string} options.apiKey - Chave da API do Google Gemini
+   * @param {Array<string>} [options.models] - Modelos a tentar em ordem
+   */
+  constructor({ apiKey, models } = {}) {
+    super();
+
+    if (!apiKey) throw new Error("GeminiTranscriberAdapter: apiKey é obrigatória.");
+
+    this.client = new GoogleGenAI({ apiKey });
+    this.models = models ?? LUMA_CONFIG.TECHNICAL.models;
+  }
+
+  /**
+   * Transcreve um buffer de áudio para texto.
+   *
+   * @param {Buffer} audioBuffer
+   * @param {string} [mimeType]
+   * @returns {Promise<string|null>} Texto transcrito, ou null se todos falharem.
+   *   Strings especiais: "[áudio ininteligível]" | "[áudio sem conteúdo]"
+   */
+  async transcribe(audioBuffer, mimeType = "audio/ogg; codecs=opus") {
+    const base64Audio = audioBuffer.toString("base64");
+    const normalizedMime = this._normalizeMimeType(mimeType);
+
+    const contents = [{
+      role: "user",
+      parts: [
+        {
+          inlineData: { data: base64Audio, mimeType: normalizedMime },
+        },
+        {
+          text: `Transcreva exatamente o que foi dito neste áudio para texto.
+Retorne APENAS a transcrição literal, sem comentários, sem prefixos como "Transcrição:" ou aspas.
+Se o áudio for ininteligível ou apenas ruído, retorne exatamente: [áudio ininteligível]
+Se o áudio estiver vazio ou silencioso, retorne exatamente: [áudio sem conteúdo]`,
+        },
+      ],
+    }];
+
+    let lastError = null;
+
+    for (const model of this.models) {
+      try {
+        Logger.info(`🎙️ GeminiTranscriberAdapter: transcrevendo com ${model}...`);
+
+        const response = await this.client.models.generateContent({
+          model,
+          contents,
+          config: { temperature: 0.1, maxOutputTokens: 1024 },
+        });
+
+        const text = this._extractText(response);
+
+        if (text) {
+          Logger.info(`✅ Transcrição concluída (${text.length} chars)`);
+          return text.trim();
+        }
+
+        lastError = new Error("Resposta vazia do modelo");
+      } catch (error) {
+        lastError = error;
+        Logger.warn(`⚠️ GeminiTranscriberAdapter: falha no ${model}: ${error.message}`);
+      }
+    }
+
+    Logger.error("❌ GeminiTranscriberAdapter: todos os modelos falharam.", lastError);
+    return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Privados
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Normaliza o mimeType do WhatsApp para um formato aceito pelo Gemini.
+   * Ex: "audio/ogg; codecs=opus" → "audio/ogg"
+   * @private
+   */
+  _normalizeMimeType(mimeType) {
+    if (!mimeType) return "audio/ogg";
+
+    const base = mimeType.split(";")[0].trim().toLowerCase();
+
+    const mimeMap = {
+      "audio/ogg":  "audio/ogg",
+      "audio/mpeg": "audio/mp3",
+      "audio/mp4":  "audio/mp4",
+      "audio/aac":  "audio/aac",
+      "audio/wav":  "audio/wav",
+      "audio/webm": "audio/webm",
+    };
+
+    return mimeMap[base] ?? "audio/ogg";
+  }
+
+  /** @private */
+  _extractText(response) {
+    const parts = response.candidates?.[0]?.content?.parts;
+    if (parts) {
+      return parts.filter((p) => p.text).map((p) => p.text).join("");
+    }
+    try { return response.text ?? ""; } catch { return ""; }
+  }
+}

--- a/src/core/ports/AIPort.js
+++ b/src/core/ports/AIPort.js
@@ -1,0 +1,26 @@
+/**
+ * Porta de IA — contrato que todo provider de inteligência artificial deve satisfazer.
+ *
+ * Fase atual (1): o parâmetro `contents` segue o formato do @google/genai para manter
+ * a migração incremental. Na Fase 3, quando LumaHandler for refatorado, este método
+ * receberá um formato normalizado independente de provider.
+ */
+export class AIPort {
+  /**
+   * Gera uma resposta com base no histórico de conversa.
+   *
+   * @param {Array} contents - Array de mensagens no formato { role, parts }
+   * @returns {Promise<{text: string, functionCalls: Array}>}
+   */
+  async generateContent(contents) {
+    throw new Error(`${this.constructor.name} não implementou AIPort.generateContent()`);
+  }
+
+  /**
+   * Retorna estatísticas de uso dos modelos (chamadas, erros, último modelo usado).
+   * @returns {Array<{model: string, successes: number, failures: number, lastError: string|null}>}
+   */
+  getStats() {
+    throw new Error(`${this.constructor.name} não implementou AIPort.getStats()`);
+  }
+}

--- a/src/core/ports/MessagingPort.js
+++ b/src/core/ports/MessagingPort.js
@@ -1,0 +1,78 @@
+/**
+ * Porta de mensageria — contrato que todo adapter de plataforma de mensagens deve satisfazer.
+ * Abstrai operações de envio para que o domínio não dependa do Baileys diretamente.
+ */
+export class MessagingPort {
+  /**
+   * Envia uma mensagem de texto.
+   * @param {string} jid - ID do chat destino
+   * @param {string} text - Conteúdo da mensagem
+   * @param {object} [options] - Opções adicionais (ex: { quoted: message })
+   * @returns {Promise<object>} Metadata da mensagem enviada
+   */
+  async sendText(jid, text, options = {}) {
+    throw new Error(`${this.constructor.name} não implementou MessagingPort.sendText()`);
+  }
+
+  /**
+   * Envia uma imagem com legenda opcional.
+   * @param {string} jid
+   * @param {Buffer} imageBuffer
+   * @param {string} [caption]
+   * @returns {Promise<object>}
+   */
+  async sendImage(jid, imageBuffer, caption = '') {
+    throw new Error(`${this.constructor.name} não implementou MessagingPort.sendImage()`);
+  }
+
+  /**
+   * Envia um arquivo de áudio.
+   * @param {string} jid
+   * @param {Buffer} audioBuffer
+   * @param {object} [options]
+   * @returns {Promise<object>}
+   */
+  async sendAudio(jid, audioBuffer, options = {}) {
+    throw new Error(`${this.constructor.name} não implementou MessagingPort.sendAudio()`);
+  }
+
+  /**
+   * Envia um vídeo.
+   * @param {string} jid
+   * @param {Buffer} videoBuffer
+   * @param {string} [caption]
+   * @returns {Promise<object>}
+   */
+  async sendVideo(jid, videoBuffer, caption = '') {
+    throw new Error(`${this.constructor.name} não implementou MessagingPort.sendVideo()`);
+  }
+
+  /**
+   * Adiciona uma reação emoji a uma mensagem.
+   * @param {string} jid
+   * @param {object} messageKey - Chave da mensagem a reagir
+   * @param {string} emoji
+   * @returns {Promise<void>}
+   */
+  async react(jid, messageKey, emoji) {
+    throw new Error(`${this.constructor.name} não implementou MessagingPort.react()`);
+  }
+
+  /**
+   * Atualiza o status de presença (typing, recording...).
+   * @param {string} jid
+   * @param {'composing'|'recording'|'paused'} type
+   * @returns {Promise<void>}
+   */
+  async sendPresence(jid, type) {
+    throw new Error(`${this.constructor.name} não implementou MessagingPort.sendPresence()`);
+  }
+
+  /**
+   * Retorna o JID do bot conectado.
+   * @returns {string}
+   */
+  getBotJid() {
+    throw new Error(`${this.constructor.name} não implementou MessagingPort.getBotJid()`);
+  }
+}

--- a/src/core/ports/SearchPort.js
+++ b/src/core/ports/SearchPort.js
@@ -1,0 +1,15 @@
+/**
+ * Porta de busca — contrato que todo adapter de busca na internet deve satisfazer.
+ * Abstrai Tavily, Google Grounding ou qualquer outro provedor de busca.
+ */
+export class SearchPort {
+  /**
+   * Realiza uma busca na internet e retorna os resultados como texto formatado.
+   *
+   * @param {string} query - Termos de busca
+   * @returns {Promise<string>} Resultados formatados como texto legível
+   */
+  async search(query) {
+    throw new Error(`${this.constructor.name} não implementou SearchPort.search()`);
+  }
+}

--- a/src/core/ports/StoragePort.js
+++ b/src/core/ports/StoragePort.js
@@ -1,0 +1,76 @@
+/**
+ * Porta de persistência — contrato que todo adapter de armazenamento deve satisfazer.
+ * Abstrai SQLite, InMemory ou qualquer outro backend de dados.
+ */
+export class StoragePort {
+  // --- Histórico de conversa ---
+
+  /**
+   * Retorna o histórico de mensagens de uma conversa.
+   * @param {string} jid - ID do chat
+   * @returns {Promise<Array<{role: string, parts: Array}>>}
+   */
+  async getConversationHistory(jid) {
+    throw new Error(`${this.constructor.name} não implementou StoragePort.getConversationHistory()`);
+  }
+
+  /**
+   * Salva uma mensagem no histórico.
+   * @param {string} jid
+   * @param {string} role - 'user' | 'model'
+   * @param {Array} parts - Array de partes da mensagem
+   * @returns {Promise<void>}
+   */
+  async saveMessage(jid, role, parts) {
+    throw new Error(`${this.constructor.name} não implementou StoragePort.saveMessage()`);
+  }
+
+  /**
+   * Remove todo o histórico de uma conversa.
+   * @param {string} jid
+   * @returns {Promise<void>}
+   */
+  async clearHistory(jid) {
+    throw new Error(`${this.constructor.name} não implementou StoragePort.clearHistory()`);
+  }
+
+  // --- Personalidades ---
+
+  /**
+   * Retorna a chave da personalidade ativa para um chat.
+   * @param {string} jid
+   * @returns {Promise<string|null>}
+   */
+  async getPersonality(jid) {
+    throw new Error(`${this.constructor.name} não implementou StoragePort.getPersonality()`);
+  }
+
+  /**
+   * Define a personalidade ativa para um chat.
+   * @param {string} jid
+   * @param {string} personalityKey
+   * @returns {Promise<void>}
+   */
+  async setPersonality(jid, personalityKey) {
+    throw new Error(`${this.constructor.name} não implementou StoragePort.setPersonality()`);
+  }
+
+  // --- Métricas ---
+
+  /**
+   * Incrementa um contador de métrica.
+   * @param {string} key - Nome da métrica (ex: 'stickers_created')
+   * @returns {Promise<void>}
+   */
+  async incrementMetric(key) {
+    throw new Error(`${this.constructor.name} não implementou StoragePort.incrementMetric()`);
+  }
+
+  /**
+   * Retorna todas as métricas acumuladas.
+   * @returns {Promise<object>}
+   */
+  async getMetrics() {
+    throw new Error(`${this.constructor.name} não implementou StoragePort.getMetrics()`);
+  }
+}

--- a/src/core/ports/TranscriberPort.js
+++ b/src/core/ports/TranscriberPort.js
@@ -1,0 +1,17 @@
+/**
+ * Porta de transcrição — contrato que todo adapter de transcrição de áudio deve satisfazer.
+ * Abstrai Gemini, Whisper ou qualquer outro modelo de Speech-to-Text.
+ */
+export class TranscriberPort {
+  /**
+   * Transcreve um buffer de áudio para texto.
+   *
+   * @param {Buffer} audioBuffer - Conteúdo binário do áudio
+   * @param {string} mimeType - Tipo MIME do áudio (ex: "audio/ogg; codecs=opus")
+   * @returns {Promise<string|null>} Texto transcrito, ou null se todos os modelos falharem.
+   *   Pode retornar strings especiais: "[áudio ininteligível]" ou "[áudio sem conteúdo]"
+   */
+  async transcribe(audioBuffer, mimeType) {
+    throw new Error(`${this.constructor.name} não implementou TranscriberPort.transcribe()`);
+  }
+}

--- a/tests/unit/adapters/GeminiAdapter.test.js
+++ b/tests/unit/adapters/GeminiAdapter.test.js
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GeminiAdapter } from '../../../src/adapters/ai/GeminiAdapter.js';
+import { AIPort } from '../../../src/core/ports/AIPort.js';
+
+// Variáveis de módulo para reconfigurar por teste
+let mockGenerateContent = vi.fn();
+
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: class {
+    constructor() {
+      this.models = {
+        generateContent: (...args) => mockGenerateContent(...args),
+      };
+    }
+  },
+}));
+
+vi.mock('../../../src/config/lumaConfig.js', () => ({
+  LUMA_CONFIG: {
+    TECHNICAL: {
+      models: ['gemini-flash', 'gemini-pro'],
+      generationConfig: { temperature: 0.7, maxOutputTokens: 2048, topP: 0.9, topK: 40 },
+    },
+    TOOLS: [],
+  },
+}));
+
+function makeSuccessResponse(text = 'resposta mock', functionCalls = []) {
+  return {
+    candidates: [{
+      content: {
+        parts: [
+          { text },
+          ...functionCalls.map(fc => ({ functionCall: fc })),
+        ],
+      },
+    }],
+  };
+}
+
+describe('GeminiAdapter — construção', () => {
+  it('instancia corretamente com apiKey', () => {
+    const adapter = new GeminiAdapter({ apiKey: 'fake-key' });
+    expect(adapter).toBeInstanceOf(GeminiAdapter);
+    expect(adapter).toBeInstanceOf(AIPort);
+  });
+
+  it('lança erro se apiKey não for fornecida', () => {
+    expect(() => new GeminiAdapter({})).toThrow('GeminiAdapter: apiKey é obrigatória.');
+  });
+
+  it('usa modelos do LUMA_CONFIG por padrão', () => {
+    const adapter = new GeminiAdapter({ apiKey: 'key' });
+    expect(adapter.models).toEqual(['gemini-flash', 'gemini-pro']);
+  });
+
+  it('aceita modelos customizados', () => {
+    const adapter = new GeminiAdapter({ apiKey: 'key', models: ['gemini-nano'] });
+    expect(adapter.models).toEqual(['gemini-nano']);
+  });
+});
+
+describe('GeminiAdapter — generateContent', () => {
+  let adapter;
+
+  beforeEach(() => {
+    mockGenerateContent = vi.fn();
+    adapter = new GeminiAdapter({ apiKey: 'fake-key', models: ['gemini-flash'] });
+  });
+
+  it('retorna text e functionCalls vazios numa resposta de texto simples', async () => {
+    mockGenerateContent.mockResolvedValue(makeSuccessResponse('Olá!'));
+    const result = await adapter.generateContent([{ role: 'user', parts: [{ text: 'oi' }] }]);
+    expect(result).toEqual({ text: 'Olá!', functionCalls: [] });
+  });
+
+  it('extrai functionCalls da resposta', async () => {
+    const fc = { name: 'create_sticker', args: { quality: 'high' } };
+    mockGenerateContent.mockResolvedValue(makeSuccessResponse('', [fc]));
+    const result = await adapter.generateContent([]);
+    expect(result.functionCalls).toHaveLength(1);
+    expect(result.functionCalls[0].name).toBe('create_sticker');
+  });
+
+  it('tenta o segundo modelo se o primeiro falhar', async () => {
+    adapter = new GeminiAdapter({ apiKey: 'key', models: ['flash', 'pro'] });
+    mockGenerateContent
+      .mockRejectedValueOnce(new Error('modelo indisponível'))
+      .mockResolvedValueOnce(makeSuccessResponse('fallback ok'));
+
+    const result = await adapter.generateContent([]);
+    expect(result.text).toBe('fallback ok');
+    expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+  });
+
+  it('lança erro quando todos os modelos falham', async () => {
+    adapter = new GeminiAdapter({ apiKey: 'key', models: ['a', 'b'] });
+    mockGenerateContent.mockRejectedValue(new Error('falha total'));
+    await expect(adapter.generateContent([])).rejects.toThrow('todos os modelos falharam');
+  });
+
+  it('incrementa stat de sucesso ao completar', async () => {
+    mockGenerateContent.mockResolvedValue(makeSuccessResponse('ok'));
+    await adapter.generateContent([]);
+    const stats = adapter.getStats();
+    expect(stats[0].successes).toBe(1);
+    expect(stats[0].failures).toBe(0);
+  });
+
+  it('incrementa stat de falha quando modelo falha', async () => {
+    adapter = new GeminiAdapter({ apiKey: 'key', models: ['falha', 'ok'] });
+    mockGenerateContent
+      .mockRejectedValueOnce(new Error('erro'))
+      .mockResolvedValueOnce(makeSuccessResponse('ok'));
+
+    await adapter.generateContent([]);
+    const stats = adapter.getStats();
+    expect(stats[0].model).toBe('falha');
+    expect(stats[0].failures).toBe(1);
+    expect(stats[1].successes).toBe(1);
+  });
+});
+
+describe('GeminiAdapter — getStats', () => {
+  it('retorna array com uma entrada por modelo', () => {
+    const adapter = new GeminiAdapter({ apiKey: 'key', models: ['a', 'b', 'c'] });
+    const stats = adapter.getStats();
+    expect(stats).toHaveLength(3);
+    expect(stats.map(s => s.model)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('cada entrada tem as propriedades obrigatórias', () => {
+    const adapter = new GeminiAdapter({ apiKey: 'key', models: ['m'] });
+    const [stat] = adapter.getStats();
+    expect(stat).toHaveProperty('model');
+    expect(stat).toHaveProperty('successes');
+    expect(stat).toHaveProperty('failures');
+    expect(stat).toHaveProperty('lastError');
+  });
+});
+
+describe('GeminiAdapter — setSearchPort', () => {
+  it('aceita um SearchPort injetado', () => {
+    const adapter = new GeminiAdapter({ apiKey: 'key' });
+    const fakeSearchPort = { search: vi.fn() };
+    adapter.setSearchPort(fakeSearchPort);
+    expect(adapter._searchPort).toBe(fakeSearchPort);
+  });
+});
+
+describe('GeminiAdapter — _normalizeMimeType (via _extractFromResponse)', () => {
+  it('extrai texto de resposta com candidates/parts', async () => {
+    const adapter = new GeminiAdapter({ apiKey: 'key', models: ['m'] });
+    mockGenerateContent.mockResolvedValue(makeSuccessResponse('resultado'));
+    const result = await adapter.generateContent([]);
+    expect(result.text).toBe('resultado');
+  });
+
+  it('concatena múltiplas partes de texto', async () => {
+    const adapter = new GeminiAdapter({ apiKey: 'key', models: ['m'] });
+    mockGenerateContent.mockResolvedValue({
+      candidates: [{
+        content: {
+          parts: [{ text: 'Parte 1. ' }, { text: 'Parte 2.' }],
+        },
+      }],
+    });
+    const result = await adapter.generateContent([]);
+    expect(result.text).toBe('Parte 1. Parte 2.');
+  });
+});

--- a/tests/unit/adapters/GeminiTranscriberAdapter.test.js
+++ b/tests/unit/adapters/GeminiTranscriberAdapter.test.js
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GeminiTranscriberAdapter } from '../../../src/adapters/transcriber/GeminiTranscriberAdapter.js';
+import { TranscriberPort } from '../../../src/core/ports/TranscriberPort.js';
+
+// Variável de módulo para reconfigurar por teste
+let mockGenerateContent = vi.fn();
+
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: class {
+    constructor() {
+      this.models = {
+        generateContent: (...args) => mockGenerateContent(...args),
+      };
+    }
+  },
+}));
+
+vi.mock('../../../src/config/lumaConfig.js', () => ({
+  LUMA_CONFIG: {
+    TECHNICAL: {
+      models: ['gemini-flash'],
+    },
+  },
+}));
+
+function makeResponse(text) {
+  return {
+    candidates: [{ content: { parts: [{ text }] } }],
+  };
+}
+
+describe('GeminiTranscriberAdapter — construção', () => {
+  it('instancia corretamente com apiKey', () => {
+    const adapter = new GeminiTranscriberAdapter({ apiKey: 'key' });
+    expect(adapter).toBeInstanceOf(GeminiTranscriberAdapter);
+    expect(adapter).toBeInstanceOf(TranscriberPort);
+  });
+
+  it('lança erro se apiKey não for fornecida', () => {
+    expect(() => new GeminiTranscriberAdapter({})).toThrow(
+      'GeminiTranscriberAdapter: apiKey é obrigatória.'
+    );
+  });
+
+  it('usa modelos do LUMA_CONFIG por padrão', () => {
+    const adapter = new GeminiTranscriberAdapter({ apiKey: 'key' });
+    expect(adapter.models).toEqual(['gemini-flash']);
+  });
+
+  it('aceita modelos customizados', () => {
+    const adapter = new GeminiTranscriberAdapter({ apiKey: 'key', models: ['gemini-nano'] });
+    expect(adapter.models).toEqual(['gemini-nano']);
+  });
+});
+
+describe('GeminiTranscriberAdapter — transcribe', () => {
+  let adapter;
+
+  beforeEach(() => {
+    mockGenerateContent = vi.fn();
+    adapter = new GeminiTranscriberAdapter({ apiKey: 'key', models: ['gemini-flash'] });
+  });
+
+  it('retorna texto transcrito em caso de sucesso', async () => {
+    mockGenerateContent.mockResolvedValue(makeResponse('Olá, tudo bem?'));
+    const result = await adapter.transcribe(Buffer.from('audio'), 'audio/ogg');
+    expect(result).toBe('Olá, tudo bem?');
+  });
+
+  it('retorna null quando todos os modelos falham', async () => {
+    mockGenerateContent.mockRejectedValue(new Error('falha'));
+    const result = await adapter.transcribe(Buffer.from('audio'), 'audio/ogg');
+    expect(result).toBeNull();
+  });
+
+  it('retorna null quando a resposta está vazia', async () => {
+    mockGenerateContent.mockResolvedValue(makeResponse(''));
+    const result = await adapter.transcribe(Buffer.from('audio'), 'audio/ogg');
+    expect(result).toBeNull();
+  });
+
+  it('retorna "[áudio ininteligível]" quando o modelo retorna esse valor', async () => {
+    mockGenerateContent.mockResolvedValue(makeResponse('[áudio ininteligível]'));
+    const result = await adapter.transcribe(Buffer.from('audio'), 'audio/ogg');
+    expect(result).toBe('[áudio ininteligível]');
+  });
+
+  it('retorna "[áudio sem conteúdo]" quando o modelo retorna esse valor', async () => {
+    mockGenerateContent.mockResolvedValue(makeResponse('[áudio sem conteúdo]'));
+    const result = await adapter.transcribe(Buffer.from('audio'), 'audio/ogg');
+    expect(result).toBe('[áudio sem conteúdo]');
+  });
+
+  it('tenta o segundo modelo se o primeiro falhar', async () => {
+    adapter = new GeminiTranscriberAdapter({ apiKey: 'key', models: ['flash', 'pro'] });
+    mockGenerateContent
+      .mockRejectedValueOnce(new Error('modelo indisponível'))
+      .mockResolvedValueOnce(makeResponse('texto transcrito'));
+
+    const result = await adapter.transcribe(Buffer.from('audio'), 'audio/ogg');
+    expect(result).toBe('texto transcrito');
+    expect(mockGenerateContent).toHaveBeenCalledTimes(2);
+  });
+
+  it('envia o áudio como base64 inlineData', async () => {
+    mockGenerateContent.mockResolvedValue(makeResponse('ok'));
+    const audioBuffer = Buffer.from('fake-audio-data');
+    await adapter.transcribe(audioBuffer, 'audio/ogg');
+
+    const callArgs = mockGenerateContent.mock.calls[0][0];
+    const inlineData = callArgs.contents[0].parts[0].inlineData;
+    expect(inlineData.data).toBe(audioBuffer.toString('base64'));
+  });
+});
+
+describe('GeminiTranscriberAdapter — _normalizeMimeType', () => {
+  let adapter;
+
+  beforeEach(() => {
+    adapter = new GeminiTranscriberAdapter({ apiKey: 'key' });
+  });
+
+  it('normaliza "audio/ogg; codecs=opus" para "audio/ogg"', () => {
+    expect(adapter._normalizeMimeType('audio/ogg; codecs=opus')).toBe('audio/ogg');
+  });
+
+  it('normaliza "audio/mpeg" para "audio/mp3"', () => {
+    expect(adapter._normalizeMimeType('audio/mpeg')).toBe('audio/mp3');
+  });
+
+  it('normaliza "audio/mp4" para "audio/mp4"', () => {
+    expect(adapter._normalizeMimeType('audio/mp4')).toBe('audio/mp4');
+  });
+
+  it('normaliza "audio/aac" para "audio/aac"', () => {
+    expect(adapter._normalizeMimeType('audio/aac')).toBe('audio/aac');
+  });
+
+  it('normaliza "audio/wav" para "audio/wav"', () => {
+    expect(adapter._normalizeMimeType('audio/wav')).toBe('audio/wav');
+  });
+
+  it('normaliza "audio/webm" para "audio/webm"', () => {
+    expect(adapter._normalizeMimeType('audio/webm')).toBe('audio/webm');
+  });
+
+  it('retorna "audio/ogg" como fallback para tipo desconhecido', () => {
+    expect(adapter._normalizeMimeType('audio/flac')).toBe('audio/ogg');
+  });
+
+  it('retorna "audio/ogg" para null/undefined', () => {
+    expect(adapter._normalizeMimeType(null)).toBe('audio/ogg');
+    expect(adapter._normalizeMimeType(undefined)).toBe('audio/ogg');
+  });
+
+  it('é case-insensitive', () => {
+    expect(adapter._normalizeMimeType('AUDIO/OGG')).toBe('audio/ogg');
+  });
+});

--- a/tests/unit/adapters/GoogleGroundingAdapter.test.js
+++ b/tests/unit/adapters/GoogleGroundingAdapter.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GoogleGroundingAdapter } from '../../../src/adapters/search/GoogleGroundingAdapter.js';
+import { SearchPort } from '../../../src/core/ports/SearchPort.js';
+
+function makeClient(responseText) {
+  return {
+    models: {
+      generateContent: vi.fn().mockResolvedValue({
+        candidates: [{
+          content: {
+            parts: [{ text: responseText }],
+          },
+        }],
+      }),
+    },
+  };
+}
+
+describe('GoogleGroundingAdapter — construção', () => {
+  it('instancia corretamente com client', () => {
+    const adapter = new GoogleGroundingAdapter({ client: makeClient('') });
+    expect(adapter).toBeInstanceOf(GoogleGroundingAdapter);
+    expect(adapter).toBeInstanceOf(SearchPort);
+  });
+
+  it('lança erro se client não for fornecido', () => {
+    expect(() => new GoogleGroundingAdapter({})).toThrow(
+      'GoogleGroundingAdapter: client (GoogleGenAI) é obrigatório.'
+    );
+  });
+
+  it('usa gemini-2.0-flash como modelo padrão', () => {
+    const adapter = new GoogleGroundingAdapter({ client: makeClient('') });
+    expect(adapter.model).toBe('gemini-2.0-flash');
+  });
+
+  it('aceita modelo customizado', () => {
+    const adapter = new GoogleGroundingAdapter({
+      client: makeClient(''),
+      model: 'gemini-pro',
+    });
+    expect(adapter.model).toBe('gemini-pro');
+  });
+});
+
+describe('GoogleGroundingAdapter — search', () => {
+  it('retorna o texto da resposta do Gemini', async () => {
+    const client = makeClient('Resultado da busca com grounding.');
+    const adapter = new GoogleGroundingAdapter({ client });
+
+    const result = await adapter.search('node.js performance');
+    expect(result).toBe('Resultado da busca com grounding.');
+  });
+
+  it('chama generateContent com a ferramenta googleSearch', async () => {
+    const client = makeClient('ok');
+    const adapter = new GoogleGroundingAdapter({ client });
+
+    await adapter.search('query');
+
+    const callArgs = client.models.generateContent.mock.calls[0][0];
+    expect(callArgs.config.tools).toEqual([{ googleSearch: {} }]);
+  });
+
+  it('inclui a query no prompt enviado ao Gemini', async () => {
+    const client = makeClient('ok');
+    const adapter = new GoogleGroundingAdapter({ client });
+
+    await adapter.search('typescript generics');
+
+    const callArgs = client.models.generateContent.mock.calls[0][0];
+    const promptText = callArgs.contents[0].parts[0].text;
+    expect(promptText).toContain('typescript generics');
+  });
+
+  it('retorna "Nenhum resultado" quando a resposta é vazia', async () => {
+    const client = {
+      models: {
+        generateContent: vi.fn().mockResolvedValue({
+          candidates: [{ content: { parts: [{ text: '' }] } }],
+        }),
+      },
+    };
+    const adapter = new GoogleGroundingAdapter({ client });
+    const result = await adapter.search('query');
+    expect(result).toBe('Nenhum resultado encontrado.');
+  });
+
+  it('retorna mensagem de erro quando generateContent lança exceção', async () => {
+    const client = {
+      models: {
+        generateContent: vi.fn().mockRejectedValue(new Error('API indisponível')),
+      },
+    };
+    const adapter = new GoogleGroundingAdapter({ client });
+    const result = await adapter.search('query');
+    expect(result).toBe('Não foi possível buscar informações no momento.');
+  });
+
+  it('concatena múltiplas parts de texto', async () => {
+    const client = {
+      models: {
+        generateContent: vi.fn().mockResolvedValue({
+          candidates: [{
+            content: {
+              parts: [{ text: 'Parte A. ' }, { text: 'Parte B.' }],
+            },
+          }],
+        }),
+      },
+    };
+    const adapter = new GoogleGroundingAdapter({ client });
+    const result = await adapter.search('query');
+    expect(result).toBe('Parte A. Parte B.');
+  });
+});

--- a/tests/unit/adapters/TavilyAdapter.test.js
+++ b/tests/unit/adapters/TavilyAdapter.test.js
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TavilyAdapter } from '../../../src/adapters/search/TavilyAdapter.js';
+import { SearchPort } from '../../../src/core/ports/SearchPort.js';
+
+function makeFetchMock(status, body) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  });
+}
+
+describe('TavilyAdapter — construção', () => {
+  it('instancia corretamente com apiKey', () => {
+    const adapter = new TavilyAdapter({ apiKey: 'key' });
+    expect(adapter).toBeInstanceOf(TavilyAdapter);
+    expect(adapter).toBeInstanceOf(SearchPort);
+  });
+
+  it('lança erro se apiKey não for fornecida', () => {
+    expect(() => new TavilyAdapter({})).toThrow('TavilyAdapter: apiKey é obrigatória.');
+  });
+
+  it('aceita adapter de fallback', () => {
+    const fallback = { search: vi.fn() };
+    const adapter = new TavilyAdapter({ apiKey: 'key', fallback });
+    expect(adapter.fallback).toBe(fallback);
+  });
+});
+
+describe('TavilyAdapter — search (Tavily disponível)', () => {
+  let adapter;
+
+  beforeEach(() => {
+    adapter = new TavilyAdapter({ apiKey: 'fake-key' });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('retorna o resumo Tavily quando disponível', async () => {
+    vi.stubGlobal('fetch', makeFetchMock(200, {
+      answer: 'Resposta resumida.',
+      results: [{ title: 'Artigo 1', content: 'Conteúdo do artigo.' }],
+    }));
+
+    const result = await adapter.search('node.js');
+    expect(result).toContain('Resumo: Resposta resumida.');
+    expect(result).toContain('Artigo 1');
+  });
+
+  it('formata até 4 resultados', async () => {
+    const results = Array.from({ length: 6 }, (_, i) => ({
+      title: `Artigo ${i + 1}`,
+      content: `Conteúdo ${i + 1}`,
+    }));
+    vi.stubGlobal('fetch', makeFetchMock(200, { results }));
+
+    const result = await adapter.search('query');
+    // Deve conter [1] a [4] mas não [5] ou [6]
+    expect(result).toContain('[4]');
+    expect(result).not.toContain('[5]');
+  });
+
+  it('retorna "Nenhum resultado" quando results vazio e sem answer', async () => {
+    vi.stubGlobal('fetch', makeFetchMock(200, { results: [] }));
+    const result = await adapter.search('query');
+    expect(result).toBe('Nenhum resultado encontrado.');
+  });
+
+  it('trunca conteúdo longo em 350 chars', async () => {
+    const longContent = 'x'.repeat(500);
+    vi.stubGlobal('fetch', makeFetchMock(200, {
+      results: [{ title: 'T', content: longContent }],
+    }));
+
+    const result = await adapter.search('q');
+    expect(result).toContain('x'.repeat(350));
+    expect(result).not.toContain('x'.repeat(351));
+  });
+});
+
+describe('TavilyAdapter — fallback por quota', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('ativa fallback quando recebe 429', async () => {
+    const fallback = { search: vi.fn().mockResolvedValue('resultado do fallback') };
+    const adapter = new TavilyAdapter({ apiKey: 'key', fallback });
+
+    vi.stubGlobal('fetch', makeFetchMock(200, { error: 'quota exceeded 429' }));
+
+    const result = await adapter.search('query');
+    expect(result).toBe('resultado do fallback');
+    expect(fallback.search).toHaveBeenCalledWith('query');
+  });
+
+  it('uma vez ativado, não tenta Tavily novamente', async () => {
+    const fallback = { search: vi.fn().mockResolvedValue('fallback') };
+    const adapter = new TavilyAdapter({ apiKey: 'key', fallback });
+
+    // Primeira chamada: simula 429 via erro HTTP
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => 'Too Many Requests',
+    }));
+
+    await adapter.search('query 1');
+    expect(adapter._quotaExceeded).toBe(true);
+
+    // Segunda chamada: fetch não deve ser chamado
+    await adapter.search('query 2');
+    expect(fetch).toHaveBeenCalledTimes(1); // só na primeira
+    expect(fallback.search).toHaveBeenCalledTimes(2);
+  });
+
+  it('resetQuota permite tentar Tavily novamente', async () => {
+    const adapter = new TavilyAdapter({ apiKey: 'key' });
+    adapter._quotaExceeded = true;
+
+    adapter.resetQuota();
+    expect(adapter._quotaExceeded).toBe(false);
+  });
+
+  it('retorna mensagem de erro quando não há fallback', async () => {
+    const adapter = new TavilyAdapter({ apiKey: 'key' }); // sem fallback
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('429 quota exceeded')));
+
+    const result = await adapter.search('query');
+    expect(result).toBe('Não foi possível buscar informações no momento.');
+  });
+});
+
+describe('TavilyAdapter — _isQuotaError', () => {
+  it('detecta mensagens com "429"', () => {
+    const a = new TavilyAdapter({ apiKey: 'k' });
+    expect(a._isQuotaError(new Error('429 too many requests'))).toBe(true);
+  });
+
+  it('detecta mensagens com "quota"', () => {
+    const a = new TavilyAdapter({ apiKey: 'k' });
+    expect(a._isQuotaError(new Error('quota exceeded'))).toBe(true);
+  });
+
+  it('detecta mensagens com "limit"', () => {
+    const a = new TavilyAdapter({ apiKey: 'k' });
+    expect(a._isQuotaError(new Error('rate limit'))).toBe(true);
+  });
+
+  it('não detecta erros genéricos', () => {
+    const a = new TavilyAdapter({ apiKey: 'k' });
+    expect(a._isQuotaError(new Error('network error'))).toBe(false);
+  });
+});

--- a/tests/unit/core/ports/ports.contract.test.js
+++ b/tests/unit/core/ports/ports.contract.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { AIPort } from '../../../../src/core/ports/AIPort.js';
+import { MessagingPort } from '../../../../src/core/ports/MessagingPort.js';
+import { StoragePort } from '../../../../src/core/ports/StoragePort.js';
+import { SearchPort } from '../../../../src/core/ports/SearchPort.js';
+import { TranscriberPort } from '../../../../src/core/ports/TranscriberPort.js';
+
+/**
+ * Testes de contrato — garantem que as portas base lançam erro quando
+ * métodos não são implementados. Isso força subclasses a implementar
+ * todos os métodos antes de serem usadas.
+ */
+
+describe('AIPort — contrato base', () => {
+  const port = new AIPort();
+
+  it('generateContent lança erro se não implementado', async () => {
+    await expect(port.generateContent([])).rejects.toThrow('AIPort não implementou AIPort.generateContent()');
+  });
+
+  it('getStats lança erro se não implementado', () => {
+    expect(() => port.getStats()).toThrow('AIPort não implementou AIPort.getStats()');
+  });
+
+  it('mensagem de erro inclui o nome da classe', async () => {
+    class MinhaIA extends AIPort {}
+    const minha = new MinhaIA();
+    await expect(minha.generateContent([])).rejects.toThrow('MinhaIA não implementou AIPort.generateContent()');
+  });
+});
+
+describe('MessagingPort — contrato base', () => {
+  const port = new MessagingPort();
+
+  it('sendText lança erro se não implementado', async () => {
+    await expect(port.sendText('jid', 'texto')).rejects.toThrow('MessagingPort não implementou MessagingPort.sendText()');
+  });
+
+  it('sendImage lança erro se não implementado', async () => {
+    await expect(port.sendImage('jid', Buffer.from(''))).rejects.toThrow();
+  });
+
+  it('sendAudio lança erro se não implementado', async () => {
+    await expect(port.sendAudio('jid', Buffer.from(''))).rejects.toThrow();
+  });
+
+  it('sendVideo lança erro se não implementado', async () => {
+    await expect(port.sendVideo('jid', Buffer.from(''))).rejects.toThrow();
+  });
+
+  it('react lança erro se não implementado', async () => {
+    await expect(port.react('jid', {}, '👍')).rejects.toThrow();
+  });
+
+  it('sendPresence lança erro se não implementado', async () => {
+    await expect(port.sendPresence('jid', 'composing')).rejects.toThrow();
+  });
+
+  it('getBotJid lança erro se não implementado', () => {
+    expect(() => port.getBotJid()).toThrow();
+  });
+});
+
+describe('StoragePort — contrato base', () => {
+  const port = new StoragePort();
+
+  it('getConversationHistory lança erro se não implementado', async () => {
+    await expect(port.getConversationHistory('jid')).rejects.toThrow();
+  });
+
+  it('saveMessage lança erro se não implementado', async () => {
+    await expect(port.saveMessage('jid', 'user', [])).rejects.toThrow();
+  });
+
+  it('clearHistory lança erro se não implementado', async () => {
+    await expect(port.clearHistory('jid')).rejects.toThrow();
+  });
+
+  it('getPersonality lança erro se não implementado', async () => {
+    await expect(port.getPersonality('jid')).rejects.toThrow();
+  });
+
+  it('setPersonality lança erro se não implementado', async () => {
+    await expect(port.setPersonality('jid', 'default')).rejects.toThrow();
+  });
+
+  it('incrementMetric lança erro se não implementado', async () => {
+    await expect(port.incrementMetric('stickers_created')).rejects.toThrow();
+  });
+
+  it('getMetrics lança erro se não implementado', async () => {
+    await expect(port.getMetrics()).rejects.toThrow();
+  });
+});
+
+describe('SearchPort — contrato base', () => {
+  const port = new SearchPort();
+
+  it('search lança erro se não implementado', async () => {
+    await expect(port.search('query')).rejects.toThrow('SearchPort não implementou SearchPort.search()');
+  });
+});
+
+describe('TranscriberPort — contrato base', () => {
+  const port = new TranscriberPort();
+
+  it('transcribe lança erro se não implementado', async () => {
+    await expect(port.transcribe(Buffer.from(''), 'audio/ogg')).rejects.toThrow(
+      'TranscriberPort não implementou TranscriberPort.transcribe()'
+    );
+  });
+});


### PR DESCRIPTION
## Resumo

- Define **5 portas** em `src/core/ports/` como contratos do domínio (independentes de tecnologia):
  - `AIPort` — geração de conteúdo com IA
  - `MessagingPort` — envio de mensagens
  - `StoragePort` — persistência (histórico, personalidades, métricas)
  - `SearchPort` — busca na internet
  - `TranscriberPort` — transcrição de áudio
- Cria **4 adapters** implementando as portas:
  - `GeminiAdapter` (AIPort): encapsula toda lógica do `@google/genai`, fallback entre modelos, loop multi-turn de busca
  - `TavilyAdapter` (SearchPort): busca Tavily com fallback automático ao atingir cota (429)
  - `GoogleGroundingAdapter` (SearchPort): fallback via Google Search Grounding do Gemini
  - `GeminiTranscriberAdapter` (TranscriberPort): transcrição multimodal com fallback entre modelos
- Código existente (`AIService`, `AudioTranscriber`, `WebSearchService`) **não foi alterado** — migração incremental, zero risco de regressão

## Testes

- **79 novos testes** cobrindo todos os adapters e contratos de porta
- **243 testes passando** no total (164 fase-0 + 79 fase-1)

## Checklist

- [x] 5 portas definidas em `src/core/ports/`
- [x] `GeminiAdapter` implementando `AIPort`
- [x] `TavilyAdapter` e `GoogleGroundingAdapter` implementando `SearchPort`
- [x] `GeminiTranscriberAdapter` implementando `TranscriberPort`
- [x] Testes de contrato para cada porta
- [x] Todos os testes da Fase 0 ainda passando
- [ ] `BaileysAdapter` refatorado para `MessagingPort` (pendente — será feito na Fase 3 junto com a decomposição dos handlers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)