### PR TITLE
feat(phase-3): decomposição dos handlers e eliminação de dependências circulares

### DIFF
--- a/src/core/services/CommandRouter.js
+++ b/src/core/services/CommandRouter.js
@@ -1,0 +1,279 @@
+import { COMMANDS, MENUS, MESSAGES } from "../../config/constants.js";
+import { Logger } from "../../utils/Logger.js";
+import { MediaProcessor } from "../../handlers/MediaProcessor.js";
+import { GroupManager } from "../../managers/GroupManager.js";
+import { VideoDownloader } from "../../services/VideoDownloader.js";
+import { VideoConverter } from "../../processors/VideoConverter.js";
+import { DatabaseService } from "../../services/Database.js";
+import { PersonalityManager } from "../../managers/PersonalityManager.js";
+import { LUMA_CONFIG } from "../../config/lumaConfig.js";
+import { extractUrl } from "../../utils/MessageUtils.js";
+import fs from "fs";
+
+/**
+ * Roteador de comandos explícitos (prefixados com `!` ou `@`).
+ *
+ * Responsabilidades:
+ * - Detectar qual comando está presente em um texto
+ * - Despachar para o handler correto
+ *
+ * Cada handler recebe apenas o `bot` (BaileysAdapter) e recursos extras via
+ * parâmetros — sem acoplar ao MessageHandler.
+ */
+export class CommandRouter {
+  /**
+   * Detecta o comando presente no texto.
+   * @param {string|null} text
+   * @returns {string|null} Uma das constantes COMMANDS ou null
+   */
+  static detect(text) {
+    if (!text) return null;
+    const lower = text.toLowerCase();
+
+    if (lower === COMMANDS.MY_NUMBER)            return COMMANDS.MY_NUMBER;
+    if (lower === COMMANDS.LUMA_CLEAR_SHORT)     return COMMANDS.LUMA_CLEAR;
+    if (lower.includes(COMMANDS.LUMA_CLEAR))     return COMMANDS.LUMA_CLEAR;
+    if (lower.includes("!clear"))                return COMMANDS.LUMA_CLEAR_ALT;
+    if (lower.includes(COMMANDS.LUMA_STATS))     return COMMANDS.LUMA_STATS;
+    if (lower.includes(COMMANDS.LUMA_STATS_SHORT)) return COMMANDS.LUMA_STATS;
+    if (lower.includes(COMMANDS.STICKER))        return COMMANDS.STICKER;
+    if (lower.includes(COMMANDS.STICKER_SHORT))  return COMMANDS.STICKER;
+    if (lower.includes(COMMANDS.IMAGE))          return COMMANDS.IMAGE;
+    if (lower.includes(COMMANDS.IMAGE_SHORT))    return COMMANDS.IMAGE;
+    if (lower.includes(COMMANDS.GIF))            return COMMANDS.GIF;
+    if (lower.includes(COMMANDS.GIF_SHORT))      return COMMANDS.GIF;
+    if (lower.includes(COMMANDS.EVERYONE.toLowerCase()) || lower === "@todos") return COMMANDS.EVERYONE;
+    if (lower.includes(COMMANDS.HELP) || lower === "!menu") return COMMANDS.HELP;
+    if (lower.startsWith(COMMANDS.PERSONA))      return COMMANDS.PERSONA;
+    if (lower.startsWith(COMMANDS.DOWNLOAD))     return COMMANDS.DOWNLOAD;
+    if (lower.startsWith(COMMANDS.DOWNLOAD_SHORT)) return COMMANDS.DOWNLOAD;
+
+    return null;
+  }
+
+  /**
+   * Executa o handler do comando detectado.
+   *
+   * @param {object} bot - BaileysAdapter
+   * @param {string} command - Constante COMMANDS retornada por detect()
+   * @param {object} [deps] - Dependências opcionais
+   * @param {object} [deps.lumaHandler] - Instância do LumaHandler (para clear/stats)
+   * @returns {Promise<boolean>} true se o comando foi tratado
+   */
+  static async dispatch(bot, command, { lumaHandler } = {}) {
+    switch (command) {
+      case COMMANDS.HELP:
+        await bot.sendText(MENUS.HELP_TEXT);
+        return true;
+
+      case COMMANDS.PERSONA:
+        await CommandRouter._sendPersonalityMenu(bot);
+        return true;
+
+      case COMMANDS.LUMA_STATS:
+      case COMMANDS.LUMA_STATS_SHORT:
+        await CommandRouter._sendStats(bot, lumaHandler);
+        return true;
+
+      case COMMANDS.LUMA_CLEAR:
+      case COMMANDS.LUMA_CLEAR_SHORT:
+      case COMMANDS.LUMA_CLEAR_ALT:
+        lumaHandler?.clearHistory(bot.jid);
+        await bot.reply("🗑️ Memória da Luma limpa nesta conversa!");
+        return true;
+
+      case COMMANDS.MY_NUMBER: {
+        const num  = await bot.getSenderNumber();
+        const chat = bot.jid;
+        await bot.reply(`📱 *Informações de ID*\n\n👤 *Seu Número:* ${num}\n💬 *ID deste Chat:* ${chat}`);
+        return true;
+      }
+
+      case COMMANDS.STICKER:
+      case COMMANDS.STICKER_SHORT:
+        await CommandRouter._handleSticker(bot);
+        return true;
+
+      case COMMANDS.IMAGE:
+      case COMMANDS.IMAGE_SHORT:
+        await CommandRouter._handleImage(bot);
+        return true;
+
+      case COMMANDS.GIF:
+      case COMMANDS.GIF_SHORT:
+        await CommandRouter._handleGif(bot);
+        return true;
+
+      case COMMANDS.DOWNLOAD: {
+        const url = extractUrl(bot.body) || extractUrl(bot.quotedText);
+        if (url) {
+          await CommandRouter._handleVideoDownload(bot, url);
+        } else {
+          await bot.reply(MESSAGES.VIDEO_NO_URL);
+        }
+        return true;
+      }
+
+      case COMMANDS.EVERYONE:
+        await bot.react("📢");
+        if (bot.isGroup) {
+          await GroupManager.mentionEveryone(bot.raw, bot.socket);
+        } else {
+          await bot.reply("⚠️ Este comando só funciona em grupos!");
+        }
+        return true;
+    }
+
+    return false;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Handlers privados
+  // ---------------------------------------------------------------------------
+
+  /** @private */
+  static async _handleSticker(bot) {
+    await bot.react("⏳");
+    const url = extractUrl(bot.body);
+    if (url) {
+      await MediaProcessor.processUrlToSticker(url, bot.socket, bot.raw);
+      CommandRouter._incrementMedia("stickers_created");
+      await bot.react("✅");
+      return;
+    }
+    if (bot.hasMedia) {
+      await MediaProcessor.processToSticker(bot.raw, bot.socket);
+      CommandRouter._incrementMedia("stickers_created");
+      await bot.react("✅");
+      return;
+    }
+    const quoted = bot.getQuotedAdapter();
+    if (quoted?.hasVisualContent) {
+      await MediaProcessor.processToSticker(quoted.raw, bot.socket, bot.jid);
+      CommandRouter._incrementMedia("stickers_created");
+      await bot.react("✅");
+    } else {
+      await bot.react("❌");
+      await bot.reply(MESSAGES.REPLY_MEDIA_STICKER);
+    }
+  }
+
+  /** @private */
+  static async _handleImage(bot) {
+    await bot.react("⏳");
+    if (bot.hasSticker) {
+      await MediaProcessor.processStickerToImage(bot.raw, bot.socket);
+      CommandRouter._incrementMedia("images_created");
+      await bot.react("✅");
+      return;
+    }
+    const quoted = bot.getQuotedAdapter();
+    if (quoted?.hasSticker) {
+      await MediaProcessor.processStickerToImage(quoted.raw, bot.socket, bot.jid);
+      CommandRouter._incrementMedia("images_created");
+      await bot.react("✅");
+    } else {
+      await bot.react("❌");
+      await bot.reply(MESSAGES.REPLY_STICKER_IMAGE);
+    }
+  }
+
+  /** @private */
+  static async _handleGif(bot) {
+    await bot.react("⏳");
+    if (bot.hasSticker) {
+      await MediaProcessor.processStickerToGif(bot.raw, bot.socket);
+      CommandRouter._incrementMedia("gifs_created");
+      await bot.react("✅");
+      return;
+    }
+    const quoted = bot.getQuotedAdapter();
+    if (quoted?.hasSticker) {
+      await MediaProcessor.processStickerToGif(quoted.raw, bot.socket, bot.jid);
+      CommandRouter._incrementMedia("gifs_created");
+      await bot.react("✅");
+    } else {
+      await bot.react("❌");
+      await bot.reply(MESSAGES.REPLY_STICKER_GIF);
+    }
+  }
+
+  /** @private */
+  static async _handleVideoDownload(bot, url) {
+    let filePath = null;
+    let convertedPath = null;
+    try {
+      await bot.react("⏳");
+      Logger.info(`🎬 Iniciando download de vídeo social: ${url}`);
+
+      filePath = await VideoDownloader.download(url);
+      Logger.info("🔄 Remuxando para compatibilidade com iOS...");
+      convertedPath = await VideoConverter.remuxForMobile(filePath);
+
+      const videoBuffer = fs.readFileSync(convertedPath);
+      await bot.socket.sendMessage(bot.jid, { video: videoBuffer, caption: MESSAGES.VIDEO_SENT });
+
+      Logger.info("✅ Vídeo social enviado com sucesso.");
+      DatabaseService.incrementMetric("videos_downloaded");
+      DatabaseService.incrementMetric("total_messages");
+      await bot.react("✅");
+    } catch (error) {
+      Logger.error("❌ Erro no download de vídeo social:", error.message);
+      if (error.message?.includes("yt-dlp") && error.message?.includes("not found")) {
+        await bot.reply(MESSAGES.YTDLP_NOT_FOUND);
+      } else if (error.message?.includes("File is larger")) {
+        await bot.reply(MESSAGES.VIDEO_TOO_LARGE);
+      } else {
+        await bot.reply(MESSAGES.VIDEO_DOWNLOAD_ERROR);
+      }
+      await bot.react("❌");
+    } finally {
+      for (const f of [filePath, convertedPath]) {
+        if (f) try { fs.unlinkSync(f); } catch (_) {}
+      }
+    }
+  }
+
+  /** @private */
+  static async _sendStats(bot, lumaHandler) {
+    const dbStats    = DatabaseService.getMetrics();
+    const memStats   = lumaHandler?.getStats() ?? { totalConversations: 0 };
+
+    const text =
+      `📊 *Estatísticas Globais da Luma*\n\n` +
+      `🧠 *Inteligência Artificial:*\n` +
+      `• Respostas Geradas: ${dbStats.ai_responses || 0}\n` +
+      `• Conversas Ativas (RAM): ${memStats.totalConversations}\n\n` +
+      `🎨 *Mídia Gerada:*\n` +
+      `• Figurinhas: ${dbStats.stickers_created || 0}\n` +
+      `• Imagens: ${dbStats.images_created || 0}\n` +
+      `• GIFs: ${dbStats.gifs_created || 0}\n` +
+      `• Vídeos Baixados: ${dbStats.videos_downloaded || 0}\n\n` +
+      `📈 *Total de Interações:* ${dbStats.total_messages || 0}`;
+
+    await bot.sendText(text);
+  }
+
+  /** @private */
+  static async _sendPersonalityMenu(bot) {
+    const list        = PersonalityManager.getList();
+    const currentName = PersonalityManager.getActiveName(bot.jid);
+
+    let text = `${MENUS.PERSONALITY.HEADER}\n`;
+    text += `🔹 Atual neste chat: ${currentName}\n\n`;
+
+    list.forEach((p, i) => {
+      const isDefault = p.key === LUMA_CONFIG.DEFAULT_PERSONALITY ? " ⭐ (Padrão)" : "";
+      text += `p${i + 1} - ${p.name}${isDefault}\n${p.desc}\n\n`;
+    });
+
+    text += MENUS.PERSONALITY.FOOTER;
+    await bot.sendText(text);
+  }
+
+  /** @private */
+  static _incrementMedia(type) {
+    DatabaseService.incrementMetric(type);
+    DatabaseService.incrementMetric("total_messages");
+  }
+}

--- a/src/core/services/GroupService.js
+++ b/src/core/services/GroupService.js
@@ -1,0 +1,66 @@
+import { Logger } from "../../utils/Logger.js";
+
+/**
+ * Serviço de operações de grupo.
+ * Encapsula lógica de grupos sem depender de nenhum handler.
+ */
+export class GroupService {
+  /**
+   * Menciona todos os participantes de um grupo.
+   * Só executa se o remetente for admin.
+   *
+   * @param {object} bot - BaileysAdapter
+   * @returns {Promise<void>}
+   */
+  static async mentionAll(bot) {
+    if (!bot.isGroup) {
+      await bot.reply("⚠️ Este comando só funciona em grupos!");
+      return;
+    }
+
+    try {
+      const groupMetadata = await bot.socket.groupMetadata(bot.jid);
+      const participants  = groupMetadata.participants;
+
+      const sender  = bot.raw.participant || bot.raw.key?.participant || bot.jid;
+      const isAdmin = participants.find((p) => p.id === sender)?.admin;
+
+      if (!isAdmin) {
+        await bot.reply("⚠️ Apenas administradores podem usar este comando!");
+        return;
+      }
+
+      const mentions = participants.map((p) => p.id);
+      const text     = participants.map((p) => `@${p.id.split("@")[0]}`).join(" ");
+
+      await bot.socket.sendMessage(bot.jid, {
+        text: `📢 *Atenção geral!*\n\n${text}`,
+        mentions,
+      });
+
+      Logger.info(`✅ Mencionados ${participants.length} participantes`);
+    } catch (error) {
+      Logger.error("GroupService: erro ao mencionar todos:", error);
+      await bot.reply("❌ Erro ao mencionar participantes").catch(() => {});
+    }
+  }
+
+  /**
+   * Verifica se um participante é admin do grupo.
+   *
+   * @param {object} sock - Socket Baileys
+   * @param {string} jid - JID do grupo
+   * @param {string} participantJid - JID do participante
+   * @returns {Promise<boolean>}
+   */
+  static async isAdmin(sock, jid, participantJid) {
+    try {
+      const groupMetadata = await sock.groupMetadata(jid);
+      const participant   = groupMetadata.participants.find((p) => p.id === participantJid);
+      return !!participant?.admin;
+    } catch (error) {
+      Logger.error("GroupService: erro ao verificar admin:", error);
+      return false;
+    }
+  }
+}

--- a/src/handlers/LumaHandler.js
+++ b/src/handlers/LumaHandler.js
@@ -4,6 +4,7 @@ import { LUMA_CONFIG } from "../config/lumaConfig.js";
 import { MediaProcessor } from "./MediaProcessor.js";
 import { PersonalityManager } from "../managers/PersonalityManager.js";
 import { DatabaseService } from "../services/Database.js";
+import { ToolDispatcher } from "./ToolDispatcher.js";
 import { env } from "../config/env.js";
 
 /**
@@ -307,6 +308,178 @@ export class LumaHandler {
   getRandomBoredResponse() {
     const responses = LUMA_CONFIG.BORED_RESPONSES;
     return responses[Math.floor(Math.random() * responses.length)];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Métodos de alto nível — chamados pelo MessageHandler
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Processa uma mensagem do usuário direcionada à Luma e envia a resposta.
+   * Substitui MessageHandler.handleLumaCommand().
+   *
+   * @param {object} bot - BaileysAdapter
+   * @param {boolean} isReply - Se é uma resposta direta a uma mensagem da Luma
+   * @param {string} groupContext - Contexto recente do grupo (para grupos)
+   */
+  async handle(bot, isReply = false, groupContext = "") {
+    try {
+      let userMessage = isReply
+        ? bot.body
+        : this.extractUserMessage(bot.body);
+
+      if (!userMessage && bot.hasVisualContent) {
+        userMessage = bot.hasSticker
+          ? "[O usuário respondeu com uma figurinha/sticker. Analise a imagem visualmente, entenda a emoção dela e reaja ao contexto]"
+          : "[O usuário enviou uma imagem. Analise o conteúdo]";
+      }
+
+      if (!userMessage) {
+        const bored  = this.getRandomBoredResponse();
+        const sent   = await bot.reply(bored);
+        if (sent?.key?.id) this.saveLastBotMessage(bot.jid, sent.key.id);
+        return;
+      }
+
+      await bot.sendPresence("composing");
+      await this._delay();
+
+      const quotedBot = bot.getQuotedAdapter();
+
+      const response = await this.generateResponse(
+        userMessage, bot.jid, bot.raw, bot.socket, bot.senderName, groupContext,
+      );
+
+      await this._dispatchResponse(bot, response, quotedBot);
+    } catch (error) {
+      Logger.error("❌ Erro no handle da Luma:", error);
+      if (error.message?.includes("API_KEY")) {
+        await bot.reply("Tô sem cérebro (API Key inválida).");
+      }
+    }
+  }
+
+  /**
+   * Processa um áudio (transcrevendo-o) e responde via Luma.
+   * Substitui MessageHandler.handleAudioTranscription().
+   *
+   * @param {object} bot - BaileysAdapter
+   * @param {object} audioTranscriber - Instância de AudioTranscriber
+   * @param {string} groupContext
+   */
+  async handleAudio(bot, audioTranscriber, groupContext = "") {
+    try {
+      if (!audioTranscriber) {
+        return await this.handle(bot, bot.isRepliedToMe, groupContext);
+      }
+
+      await bot.sendPresence("composing");
+      await bot.react("🎙️");
+
+      // Resolve a fonte do áudio: mensagem direta ou quoted
+      let audioRaw, mimeType;
+      if (bot.hasAudio) {
+        audioRaw = bot.raw;
+        mimeType = bot.audioMimeType;
+      } else {
+        const quotedAdapter = bot.getQuotedAdapter();
+        if (!quotedAdapter) return await this.handle(bot, bot.isRepliedToMe, groupContext);
+        audioRaw = quotedAdapter.raw;
+        mimeType = bot.quotedAudioMimeType;
+      }
+
+      Logger.info("🎙️ Baixando áudio para transcrição...");
+      const audioBuffer = await MediaProcessor.downloadMedia(audioRaw, bot.socket);
+
+      if (!audioBuffer || audioBuffer.length === 0) {
+        Logger.warn("⚠️ Áudio vazio ou falha no download.");
+        await bot.reply("⚠️ Não consegui baixar o áudio para transcrever.");
+        return;
+      }
+
+      Logger.info(`📊 Áudio baixado: ${(audioBuffer.length / 1024).toFixed(1)}KB`);
+      const transcription = await audioTranscriber.transcribe(audioBuffer, mimeType);
+
+      if (!transcription) {
+        await bot.reply("⚠️ Não consegui transcrever esse áudio.");
+        return;
+      }
+
+      if (transcription === "[áudio ininteligível]" || transcription === "[áudio sem conteúdo]") {
+        const desc = transcription === "[áudio ininteligível]"
+          ? "não consegui entender o que foi dito"
+          : "ele estava vazio ou silencioso";
+        await bot.reply(`🎙️ _Tentei ouvir o áudio, mas ${desc}._`);
+        return;
+      }
+
+      Logger.info(`✅ Transcrição: "${transcription.substring(0, 80)}..."`);
+      await bot.sendText(`🎙️ _"${transcription}"_`, { quoted: bot.raw });
+
+      const userText = bot.body ? this.extractUserMessage(bot.body) : "";
+      const enrichedMessage = userText
+        ? `[O usuário respondeu a um áudio com a transcrição: "${transcription}"] ${userText}`
+        : `[O usuário pediu pra você ouvir/responder o seguinte áudio que foi transcrito: "${transcription}"]`;
+
+      await this._respondWithMessage(bot, enrichedMessage, groupContext);
+    } catch (error) {
+      Logger.error("❌ Erro no fluxo de transcrição:", error);
+      await this.handle(bot, bot.isRepliedToMe, groupContext);
+    }
+  }
+
+  /**
+   * Responde com uma mensagem já construída (usada internamente e pelo handleAudio).
+   * @private
+   */
+  async _respondWithMessage(bot, message, groupContext = "") {
+    await bot.sendPresence("composing");
+    await this._delay();
+
+    const quotedBot = bot.getQuotedAdapter();
+
+    const response = await this.generateResponse(
+      message, bot.jid, bot.raw, bot.socket, bot.senderName, groupContext,
+    );
+
+    await this._dispatchResponse(bot, response, quotedBot);
+  }
+
+  /**
+   * Envia as partes da resposta e despacha tool calls.
+   * @private
+   */
+  async _dispatchResponse(bot, response, quotedBot) {
+    if (response.parts?.length > 0) {
+      const lastSent = await this._sendParts(bot, response.parts);
+      if (lastSent?.key?.id) this.saveLastBotMessage(bot.jid, lastSent.key.id);
+    }
+
+    if (response.toolCalls?.length > 0) {
+      await ToolDispatcher.handleToolCalls(bot, response.toolCalls, this, quotedBot);
+    }
+  }
+
+  /**
+   * Envia partes de texto em cadeia, cada parte citando a anterior.
+   * @private
+   */
+  async _sendParts(bot, parts) {
+    let lastSent = null;
+    for (const part of parts) {
+      if (!lastSent) {
+        lastSent = await bot.reply(part);
+      } else {
+        lastSent = await bot.socket.sendMessage(bot.jid, { text: part, quoted: lastSent });
+      }
+    }
+    return lastSent;
+  }
+
+  /** @private */
+  async _delay() {
+    const { min, max } = LUMA_CONFIG.TECHNICAL.thinkingDelay;
+    await new Promise((r) => setTimeout(r, min + Math.random() * (max - min)));
   }
 
   _getErrorResponse(type, error = null) {

--- a/src/handlers/MediaProcessor.js
+++ b/src/handlers/MediaProcessor.js
@@ -5,22 +5,26 @@ import fs from "fs";
 import path from "path";
 import { CONFIG, MESSAGES } from "../config/constants.js";
 import { Logger } from "../utils/Logger.js";
-import { MessageHandler } from "./MessageHandler.js";
+import { getMessageType } from "../utils/MessageUtils.js";
 import { ImageProcessor } from "../processors/ImageProcessor.js";
 import { VideoConverter } from "../processors/VideoConverter.js";
 import { FileSystem } from "../utils/FileSystem.js";
 
 const execAsync = promisify(exec);
 
+/** Envia texto simples via socket sem depender do MessageHandler. */
+async function sendText(sock, jid, text) {
+  try {
+    await sock.sendMessage(jid, { text });
+  } catch (e) {
+    Logger.error("MediaProcessor: erro ao enviar texto:", e);
+  }
+}
+
 export class MediaProcessor {
   static async processToSticker(message, sock, targetJid = null) {
-    if (
-      message.message?.viewOnceMessage ||
-      message.message?.viewOnceMessageV2
-    ) {
-      Logger.info(
-        "Mensagem de visualização única. Sticker não pode ser criado"
-      );
+    if (message.message?.viewOnceMessage || message.message?.viewOnceMessageV2) {
+      Logger.info("Mensagem de visualização única. Sticker não pode ser criado");
       return;
     }
     try {
@@ -28,11 +32,11 @@ export class MediaProcessor {
       const buffer = await this.downloadMedia(message, sock);
 
       if (!buffer) {
-        await MessageHandler.sendMessage(sock, jid, MESSAGES.DOWNLOAD_ERROR);
+        await sendText(sock, jid, MESSAGES.DOWNLOAD_ERROR);
         return;
       }
 
-      const type = MessageHandler.getMessageType(message);
+      const type = getMessageType(message);
       let stickerBuffer;
 
       if (type === "image") {
@@ -45,15 +49,11 @@ export class MediaProcessor {
         await sock.sendMessage(jid, { sticker: stickerBuffer });
         Logger.info("✅ Sticker enviado");
       } else {
-        await MessageHandler.sendMessage(sock, jid, MESSAGES.CONVERSION_ERROR);
+        await sendText(sock, jid, MESSAGES.CONVERSION_ERROR);
       }
     } catch (error) {
       Logger.error("Erro:", error);
-      await MessageHandler.sendMessage(
-        sock,
-        targetJid || message.key.remoteJid,
-        MESSAGES.GENERAL_ERROR
-      );
+      await sendText(sock, targetJid || message.key.remoteJid, MESSAGES.GENERAL_ERROR);
     }
   }
 
@@ -63,25 +63,16 @@ export class MediaProcessor {
       const buffer = await this.downloadMedia(message, sock);
 
       if (!buffer) {
-        await MessageHandler.sendMessage(sock, jid, MESSAGES.DOWNLOAD_ERROR);
+        await sendText(sock, jid, MESSAGES.DOWNLOAD_ERROR);
         return;
       }
 
       const imageBuffer = await ImageProcessor.toPng(buffer);
-
-      await sock.sendMessage(jid, {
-        image: imageBuffer,
-        caption: MESSAGES.CONVERTED_IMAGE,
-      });
-
+      await sock.sendMessage(jid, { image: imageBuffer, caption: MESSAGES.CONVERTED_IMAGE });
       Logger.info("✅ Imagem enviada");
     } catch (error) {
       Logger.error("Erro:", error);
-      await MessageHandler.sendMessage(
-        sock,
-        targetJid || message.key.remoteJid,
-        MESSAGES.CONVERSION_ERROR
-      );
+      await sendText(sock, targetJid || message.key.remoteJid, MESSAGES.CONVERSION_ERROR);
     }
   }
 
@@ -89,25 +80,18 @@ export class MediaProcessor {
     try {
       Logger.info("🎬 Convertendo sticker para GIF...");
       const jid = targetJid || message.key.remoteJid;
-
       const buffer = await this.downloadMedia(message, sock);
 
       if (!buffer) {
-        await MessageHandler.sendMessage(sock, jid, MESSAGES.DOWNLOAD_ERROR);
+        await sendText(sock, jid, MESSAGES.DOWNLOAD_ERROR);
         return;
       }
 
-      Logger.info("📁 Sticker baixado");
-      Logger.info(`📊 Tamanho: ${(buffer.length / 1024).toFixed(1)}KB`);
-
+      Logger.info(`📁 Sticker baixado — ${(buffer.length / 1024).toFixed(1)}KB`);
       await this.processAnimatedSticker(buffer, sock, jid);
     } catch (error) {
       Logger.error("❌ Erro geral:", error);
-      await MessageHandler.sendMessage(
-        sock,
-        targetJid || message.key.remoteJid,
-        MESSAGES.CONVERSION_ERROR
-      );
+      await sendText(sock, targetJid || message.key.remoteJid, MESSAGES.CONVERSION_ERROR);
     }
   }
 
@@ -117,19 +101,15 @@ export class MediaProcessor {
 
     try {
       const metadata = await ImageProcessor.getMetadata(buffer);
-      Logger.info(
-        `📐 Dimensões: ${metadata.width}x${metadata.height}, páginas: ${metadata.pages || 1
-        }`
-      );
+      Logger.info(`📐 Dimensões: ${metadata.width}x${metadata.height}, páginas: ${metadata.pages || 1}`);
 
       if (!metadata.pages || metadata.pages === 1) {
-        await MessageHandler.sendMessage(sock, jid, MESSAGES.STATIC_STICKER);
+        await sendText(sock, jid, MESSAGES.STATIC_STICKER);
         fs.rmSync(tempDir, { recursive: true, force: true });
         return;
       }
 
       Logger.info(`🎞️ Sticker tem ${metadata.pages} frames`);
-
       await this.extractFrames(buffer, tempDir, metadata.pages);
       await this.createAndSendGif(tempDir, sock, jid);
     } catch (error) {
@@ -142,11 +122,9 @@ export class MediaProcessor {
 
   static async extractFrames(buffer, tempDir, pageCount) {
     Logger.info("🔄 Extraindo frames do sticker animado...");
-
     for (let i = 0; i < Math.min(pageCount, CONFIG.MAX_GIF_FRAMES); i++) {
       await ImageProcessor.extractFrame(buffer, i, tempDir);
     }
-
     Logger.info("✅ Frames extraídos");
   }
 
@@ -158,9 +136,7 @@ export class MediaProcessor {
       throw new Error("GIF não foi criado");
     }
 
-    const gifSizeKB = (fs.statSync(gifOutput).size / 1024).toFixed(1);
-    Logger.info(`✅ GIF criado: ${gifSizeKB}KB`);
-
+    Logger.info(`✅ GIF criado: ${(fs.statSync(gifOutput).size / 1024).toFixed(1)}KB`);
     Logger.info("🔄 Convertendo GIF → MP4 para WhatsApp...");
     const mp4Output = await VideoConverter.toMp4(gifOutput);
 
@@ -169,15 +145,9 @@ export class MediaProcessor {
     }
 
     const mp4Buffer = fs.readFileSync(mp4Output);
-    const mp4SizeKB = (mp4Buffer.length / 1024).toFixed(1);
-    Logger.info(`✅ MP4 criado: ${mp4SizeKB}KB`);
+    Logger.info(`✅ MP4 criado: ${(mp4Buffer.length / 1024).toFixed(1)}KB`);
 
-    await sock.sendMessage(jid, {
-      video: mp4Buffer,
-      caption: MESSAGES.CONVERTED_GIF,
-      gifPlayback: true,
-    });
-
+    await sock.sendMessage(jid, { video: mp4Buffer, caption: MESSAGES.CONVERTED_GIF, gifPlayback: true });
     Logger.info("✅ Enviado como GIF animado!");
     FileSystem.cleanupFiles([mp4Output, gifOutput]);
   }
@@ -185,17 +155,11 @@ export class MediaProcessor {
   static async tryAlternativeMethod(buffer, sock, jid) {
     try {
       Logger.info("🔄 Tentando método alternativo...");
-
-      const inputWebp = path.join(
-        CONFIG.TEMP_DIR,
-        `sticker_${Date.now()}.webp`
-      );
+      const inputWebp = path.join(CONFIG.TEMP_DIR, `sticker_${Date.now()}.webp`);
       fs.writeFileSync(inputWebp, buffer);
 
       const gifOutput = path.join(CONFIG.TEMP_DIR, `gif_${Date.now()}.gif`);
-
       const altCmd = `ffmpeg -y -i "${inputWebp}" -vf "fps=${CONFIG.GIF_FPS},scale=512:512:flags=lanczos" -loop 0 "${gifOutput}"`;
-
       await execAsync(altCmd);
 
       if (!fs.existsSync(gifOutput) || fs.statSync(gifOutput).size === 0) {
@@ -203,14 +167,9 @@ export class MediaProcessor {
       }
 
       const mp4Output = await VideoConverter.toMp4(gifOutput);
-
       if (fs.existsSync(mp4Output)) {
         const mp4Buffer = fs.readFileSync(mp4Output);
-        await sock.sendMessage(jid, {
-          video: mp4Buffer,
-          caption: MESSAGES.CONVERTED_GIF,
-          gifPlayback: true,
-        });
+        await sock.sendMessage(jid, { video: mp4Buffer, caption: MESSAGES.CONVERTED_GIF, gifPlayback: true });
         Logger.info("✅ Método alternativo funcionou!");
         FileSystem.cleanupFiles([mp4Output]);
       }
@@ -218,7 +177,7 @@ export class MediaProcessor {
       FileSystem.cleanupFiles([inputWebp, gifOutput]);
     } catch (error) {
       Logger.error("Todos os métodos falharam", error);
-      await MessageHandler.sendMessage(sock, jid, MESSAGES.UNSUPPORTED_FORMAT);
+      await sendText(sock, jid, MESSAGES.UNSUPPORTED_FORMAT);
     }
   }
 
@@ -231,37 +190,21 @@ export class MediaProcessor {
 
       const msgType = Object.keys(message.message)[0];
       const mediaContent = message.message[msgType];
-
       Logger.info(`📥 Iniciando download de mídia (tipo: ${msgType})...`);
 
       if (mediaContent && !mediaContent.mediaKey && !mediaContent.url && !mediaContent.directPath) {
-        Logger.warn(`⚠️ Mídia do tipo ${msgType} pode estar sem mediaKey válido. O download pode falhar.`);
+        Logger.warn(`⚠️ Mídia do tipo ${msgType} pode estar sem mediaKey válido.`);
       }
 
-      const buffer = await downloadMediaMessage(
-        message,
-        "buffer",
-        {},
-        {
-          logger: undefined,
-          reuploadRequest: sock.updateMediaMessage,
-        }
-      );
+      const buffer = await downloadMediaMessage(message, "buffer", {}, {
+        logger: undefined,
+        reuploadRequest: sock.updateMediaMessage,
+      });
 
-      if (buffer) {
-        Logger.info(`✅ Download concluído. Tamanho: ${(buffer.length / 1024).toFixed(1)} KB`);
-      }
+      if (buffer) Logger.info(`✅ Download concluído. Tamanho: ${(buffer.length / 1024).toFixed(1)} KB`);
       return buffer;
     } catch (error) {
       Logger.error(`❌ Erro ao baixar mídia (${error.message}):`, error);
-
-      try {
-        const msgType = Object.keys(message?.message || {})[0];
-        const mediaContent = message?.message?.[msgType];
-        Logger.debug(`🔍 Detalhes para debug -> Tipo: ${msgType} | Tem mediaKey? ${!!mediaContent?.mediaKey} | Tem url? ${!!mediaContent?.url} | Tem directPath? ${!!mediaContent?.directPath}`);
-      } catch (e) {
-        // Ignora erro ao logar debug
-      }
       return null;
     }
   }
@@ -271,54 +214,29 @@ export class MediaProcessor {
 
     try {
       Logger.info(`🔗 Baixando mídia da URL: ${url}`);
-      await MessageHandler.sendMessage(
-        sock,
-        jid,
-        "🔄 Baixando mídia da URL..."
-      );
+      await sendText(sock, jid, "🔄 Baixando mídia da URL...");
 
       const response = await fetch(url);
-
-      if (!response.ok) {
-        throw new Error(`Falha ao baixar: ${response.statusText}`);
-      }
+      if (!response.ok) throw new Error(`Falha ao baixar: ${response.statusText}`);
 
       const contentType = response.headers.get("content-type");
       const contentLength = response.headers.get("content-length");
 
-      if (
-        contentLength &&
-        parseInt(contentLength) > CONFIG.MAX_FILE_SIZE * 1024 * 5
-      ) {
-        await MessageHandler.sendMessage(
-          sock,
-          jid,
-          "❌ Arquivo muito grande para processar."
-        );
+      if (contentLength && parseInt(contentLength) > CONFIG.MAX_FILE_SIZE * 1024 * 5) {
+        await sendText(sock, jid, "❌ Arquivo muito grande para processar.");
         return;
       }
 
-      const arrayBuffer = await response.arrayBuffer();
-      const buffer = Buffer.from(arrayBuffer);
-
-      if (!buffer || buffer.length === 0) {
-        throw new Error("Buffer vazio");
-      }
+      const buffer = Buffer.from(await response.arrayBuffer());
+      if (!buffer || buffer.length === 0) throw new Error("Buffer vazio");
 
       let stickerBuffer;
-
-      if (
-        contentType &&
-        (contentType.startsWith("video/") || contentType.includes("gif"))
-      ) {
-        const isGif = contentType.includes("gif");
-        stickerBuffer = await VideoConverter.toSticker(buffer, isGif);
+      if (contentType && (contentType.startsWith("video/") || contentType.includes("gif"))) {
+        stickerBuffer = await VideoConverter.toSticker(buffer, contentType.includes("gif"));
       } else if (contentType && contentType.startsWith("image/")) {
         stickerBuffer = await ImageProcessor.toSticker(buffer);
       } else {
-        Logger.warn(
-          `⚠️ Content-Type desconhecido: ${contentType}, tentando como imagem.`
-        );
+        Logger.warn(`⚠️ Content-Type desconhecido: ${contentType}, tentando como imagem.`);
         stickerBuffer = await ImageProcessor.toSticker(buffer);
       }
 
@@ -326,15 +244,11 @@ export class MediaProcessor {
         await sock.sendMessage(jid, { sticker: stickerBuffer });
         Logger.info("✅ Sticker via URL enviado");
       } else {
-        await MessageHandler.sendMessage(sock, jid, MESSAGES.CONVERSION_ERROR);
+        await sendText(sock, jid, MESSAGES.CONVERSION_ERROR);
       }
     } catch (error) {
       Logger.error("Erro ao processar URL:", error);
-      await MessageHandler.sendMessage(
-        sock,
-        jid,
-        "❌ Erro ao baixar ou converter o link."
-      );
+      await sendText(sock, jid, "❌ Erro ao baixar ou converter o link.");
     }
   }
 }

--- a/src/handlers/MessageHandler.js
+++ b/src/handlers/MessageHandler.js
@@ -1,31 +1,21 @@
-import { COMMANDS, CONFIG, MESSAGES, MENUS } from "../config/constants.js";
+import { CONFIG, MENUS } from "../config/constants.js";
 import { Logger } from "../utils/Logger.js";
-import { MediaProcessor } from "./MediaProcessor.js";
-import { GroupManager } from "../managers/GroupManager.js";
 import { LumaHandler } from "./LumaHandler.js";
-import { LUMA_CONFIG } from "../config/lumaConfig.js";
-import { DatabaseService } from "../services/Database.js";
-import { PersonalityManager } from "../managers/PersonalityManager.js";
-import { ToolDispatcher } from "./ToolDispatcher.js";
 import { AudioTranscriber } from "../services/AudioTranscriber.js";
-import { VideoDownloader } from "../services/VideoDownloader.js";
-import { VideoConverter } from "../processors/VideoConverter.js";
 import { SpontaneousHandler } from "./SpontaneousHandler.js";
+import { PersonalityManager } from "../managers/PersonalityManager.js";
+import { CommandRouter } from "../core/services/CommandRouter.js";
+import { LUMA_CONFIG } from "../config/lumaConfig.js";
 import { env } from "../config/env.js";
-import fs from "fs";
 
 /**
- * Controlador central de mensagens do bot.
- * Orquestra comandos explícitos (!sticker, !help), gatilhos da Luma
- * e despacho de ferramentas da IA.
+ * Orquestrador central de mensagens.
+ * Coordena: easter eggs → menu → comandos → áudio → Luma → espontâneo.
+ * Toda lógica de negócio vive nos serviços (CommandRouter, LumaHandler, etc.).
  */
 export class MessageHandler {
   static lumaHandler = new LumaHandler();
-
-  // Instância única do transcritor — inicializada de forma lazy
   static _audioTranscriber = null;
-
-  // Buffer de mensagens recentes por grupo (jid → [{name, text}])
   static _groupBuffer = new Map();
 
   static get audioTranscriber() {
@@ -35,11 +25,50 @@ export class MessageHandler {
     return this._audioTranscriber;
   }
 
-  /**
-   * Adiciona uma mensagem ao buffer de contexto do grupo.
-   * Mantém apenas as últimas N mensagens (TECHNICAL.groupContextSize).
-   * @private
-   */
+  /** Ponto de entrada: uma mensagem recebida pelo bot. */
+  static async process(bot) {
+    if (CONFIG.IGNORE_SELF && bot.isFromMe) return;
+
+    if (bot.isGroup && !bot.isFromMe) {
+      SpontaneousHandler.trackActivity(bot.jid);
+      if (bot.body) this._addToGroupBuffer(bot.jid, bot.body, bot.senderName);
+    }
+
+    await this._handleEasterEggs(bot);
+
+    if (bot.body && await this._handleMenuReply(bot)) return;
+
+    const command = CommandRouter.detect(bot.body);
+    if (command) {
+      const handled = await CommandRouter.dispatch(bot, command, { lumaHandler: this.lumaHandler });
+      if (handled) return;
+    }
+
+    const isPrivate    = !bot.isGroup;
+    const isReplyToBot = bot.isRepliedToMe;
+    const isTriggered  = bot.body && LumaHandler.isTriggered(bot.body);
+    const groupContext = bot.isGroup ? this._getGroupContext(bot.jid) : "";
+
+    if (bot.hasAudio && (isPrivate || isReplyToBot)) {
+      return await this.lumaHandler.handleAudio(bot, this.audioTranscriber, groupContext);
+    }
+    if (bot.quotedHasAudio && (isPrivate || isReplyToBot || isTriggered)) {
+      return await this.lumaHandler.handleAudio(bot, this.audioTranscriber, groupContext);
+    }
+
+    if (isPrivate || isReplyToBot || isTriggered) {
+      return await this.lumaHandler.handle(bot, isReplyToBot, groupContext);
+    }
+
+    if (bot.isGroup && (bot.body || bot.hasVisualContent)) {
+      await SpontaneousHandler.handle(bot, this.lumaHandler);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Privados
+  // ---------------------------------------------------------------------------
+
   static _addToGroupBuffer(jid, text, senderName) {
     const { groupContextSize } = LUMA_CONFIG.TECHNICAL;
     const buf = this._groupBuffer.get(jid) ?? [];
@@ -48,613 +77,43 @@ export class MessageHandler {
     this._groupBuffer.set(jid, buf);
   }
 
-  /**
-   * Retorna o contexto do grupo formatado para o prompt da IA.
-   * @private
-   */
   static _getGroupContext(jid) {
     const buf = this._groupBuffer.get(jid);
     if (!buf?.length) return "";
-    return buf.map(m => `${m.name}: ${m.text}`).join("\n");
+    return buf.map((m) => `${m.name}: ${m.text}`).join("\n");
   }
 
-  /**
-   * Ponto de entrada principal para cada mensagem recebida.
-   * Fluxo: validações → comandos → transcrição de áudio → Luma IA.
-   */
-  static async process(bot) {
-    const text = bot.body;
-
-    if (CONFIG.IGNORE_SELF && bot.isFromMe) return;
-
-    // Rastreia atividade e bufferiza contexto para mensagens de grupo de outros usuários
-    if (bot.isGroup && !bot.isFromMe) {
-      SpontaneousHandler.trackActivity(bot.jid);
-      if (text) this._addToGroupBuffer(bot.jid, text, bot.senderName);
-    }
-
-    await this._handleEasterEggs(bot);
-
-    if (text) {
-      if (await this.handleMenuReply(bot, text)) return;
-
-      const command = this.detectCommand(text);
-      if (command) {
-        const handled = await this._executeExplicitCommand(bot, command, text);
-        if (handled) return;
-      }
-
-    }
-
-    const isReplyToBot = bot.isRepliedToMe;
-    const isTriggered = text && LumaHandler.isTriggered(text);
-    const isPrivateChat = !bot.isGroup;
-
-    // --- Fluxo de Transcrição de Áudio ---
-    // Áudio direto no PV ou em resposta à Luma — não precisa de trigger
-    if (bot.hasAudio && (isPrivateChat || isReplyToBot)) {
-      return await this.handleAudioTranscription(bot);
-    }
-    // Áudio citado/respondido com trigger (ou privado)
-    if (bot.quotedHasAudio && (isPrivateChat || isReplyToBot || isTriggered)) {
-      return await this.handleAudioTranscription(bot);
-    }
-
-    if (isPrivateChat || isReplyToBot || isTriggered) {
-      const groupContext = bot.isGroup ? this._getGroupContext(bot.jid) : "";
-      return await this.handleLumaCommand(bot, isReplyToBot, groupContext);
-    }
-
-    // Mensagem de grupo sem trigger — chance de interação espontânea (texto ou imagem)
-    if (bot.isGroup && (text || bot.hasVisualContent)) {
-      await SpontaneousHandler.handle(bot, this.lumaHandler);
-    }
-  }
-
-  /**
-   * Fluxo de transcrição: baixa o áudio citado, transcreve via Gemini
-   * e injeta o texto no pipeline normal da Luma.
-   */
-  static async handleAudioTranscription(bot) {
-    try {
-      const transcriber = this.audioTranscriber;
-
-      if (!transcriber) {
-        Logger.warn("⚠️ AudioTranscriber não disponível (API Key ausente).");
-        return await this.handleLumaCommand(bot, bot.isRepliedToMe);
-      }
-
-      await bot.sendPresence("composing");
-      await bot.react("🎙️");
-
-      // Resolve a fonte do áudio: direto na mensagem ou no quoted
-      let audioRaw, mimeType;
-      if (bot.hasAudio) {
-        audioRaw = bot.raw;
-        mimeType = bot.audioMimeType;
-      } else {
-        const quotedAdapter = bot.getQuotedAdapter();
-        if (!quotedAdapter) {
-          return await this.handleLumaCommand(bot, bot.isRepliedToMe);
-        }
-        audioRaw = quotedAdapter.raw;
-        mimeType = bot.quotedAudioMimeType;
-      }
-
-      Logger.info("🎙️ Baixando áudio para transcrição...");
-      const audioBuffer = await MediaProcessor.downloadMedia(
-        audioRaw,
-        bot.socket
-      );
-
-      if (!audioBuffer || audioBuffer.length === 0) {
-        Logger.warn("⚠️ Áudio vazio ou falha no download.");
-        await bot.reply("⚠️ Não consegui baixar o áudio para transcrever.");
-        return;
-      }
-
-      Logger.info(`📊 Áudio baixado: ${(audioBuffer.length / 1024).toFixed(1)}KB`);
-      const transcription = await transcriber.transcribe(audioBuffer, mimeType);
-
-      if (!transcription) {
-        await bot.reply("⚠️ Não consegui transcrever esse áudio.");
-        return;
-      }
-
-      // Áudio ininteligível ou vazio — responde com contexto
-      if (
-        transcription === "[áudio ininteligível]" ||
-        transcription === "[áudio sem conteúdo]"
-      ) {
-        await bot.reply(
-          `🎙️ _Tentei ouvir o áudio, mas ${transcription === "[áudio ininteligível]"
-            ? "não consegui entender o que foi dito"
-            : "ele estava vazio ou silencioso"
-          }._`
-        );
-        return;
-      }
-
-      Logger.info(`✅ Transcrição: "${transcription.substring(0, 80)}..."`);
-
-      // Exibe a transcrição para o usuário antes de responder
-      await bot.sendText(
-        `🎙️ _"${transcription}"_`,
-        { quoted: bot.raw }
-      );
-
-      // Constrói a mensagem da Luma: contexto do áudio + mensagem original do usuário
-      const userText = bot.body
-        ? this.lumaHandler.extractUserMessage(bot.body)
-        : "";
-
-      const enrichedMessage = userText
-        ? `[O usuário respondeu a um áudio com a transcrição: "${transcription}"] ${userText}`
-        : `[O usuário pediu pra você ouvir/responder o seguinte áudio que foi transcrito: "${transcription}"]`;
-
-      // Passa o texto enriquecido diretamente para o pipeline da Luma
-      const groupContext = bot.isGroup ? this._getGroupContext(bot.jid) : "";
-      await this._callLumaWithMessage(bot, enrichedMessage, groupContext);
-    } catch (error) {
-      Logger.error("❌ Erro no fluxo de transcrição:", error);
-      // Fallback: tenta responder normalmente sem o áudio
-      await this.handleLumaCommand(bot, bot.isRepliedToMe);
-    }
-  }
-
-  /**
-   * Chama a Luma com uma mensagem já processada (sem extrair novamente do body).
-   * Usado pelo fluxo de transcrição para injetar o texto transcrito.
-   * @private
-   */
-  static async _callLumaWithMessage(bot, message, groupContext = "") {
-    try {
-      const senderName = bot.senderName;
-
-      await bot.sendPresence("composing");
-      await this.randomDelay();
-
-      const quotedBot = bot.getQuotedAdapter();
-
-      const response = await this.lumaHandler.generateResponse(
-        message,
-        bot.jid,
-        bot.raw,
-        bot.socket,
-        senderName,
-        groupContext,
-      );
-
-      if (response.parts?.length > 0) {
-        const lastSent = await this._sendParts(bot, response.parts);
-        if (lastSent?.key?.id) {
-          this.lumaHandler.saveLastBotMessage(bot.jid, lastSent.key.id);
-        }
-      }
-
-      if (response.toolCalls && response.toolCalls.length > 0) {
-        await ToolDispatcher.handleToolCalls(
-          bot,
-          response.toolCalls,
-          this.lumaHandler,
-          quotedBot
-        );
-      }
-    } catch (error) {
-      Logger.error("❌ Erro ao chamar Luma com mensagem injetada:", error);
-    }
-  }
-
-  /**
-   * Envia uma lista de partes de texto em cadeia:
-   * a primeira cita a mensagem original do usuário,
-   * as seguintes citam a parte anterior do bot.
-   * @returns {Promise<object|null>} A última mensagem enviada
-   */
-  static async _sendParts(bot, parts) {
-    let lastSent = null;
-    for (const part of parts) {
-      if (!lastSent) {
-        // Primeira parte: cita a mensagem original do usuário
-        lastSent = await bot.reply(part);
-      } else {
-        // Partes seguintes: citam a parte anterior do bot
-        lastSent = await bot.socket.sendMessage(bot.jid, {
-          text: part,
-          quoted: lastSent,
-        });
-      }
-    }
-    return lastSent;
-  }
-
-  /**
-   * Roteia comandos com prefixo (ex: !sticker, !help, !persona).
-   * @private
-   */
-  static async _executeExplicitCommand(bot, command, text) {
-    const jid = bot.jid;
-    switch (command) {
-      case COMMANDS.HELP:
-        await bot.sendText(MENUS.HELP_TEXT);
-        return true;
-      case COMMANDS.PERSONA:
-        await this.sendPersonalityMenu(bot);
-        return true;
-      case COMMANDS.LUMA_STATS:
-      case COMMANDS.LUMA_STATS_SHORT:
-        await this.sendStats(bot);
-        return true;
-      case COMMANDS.LUMA_CLEAR:
-      case COMMANDS.LUMA_CLEAR_SHORT:
-      case COMMANDS.LUMA_CLEAR_ALT:
-        this.lumaHandler.clearHistory(jid);
-        await bot.reply("🗑️ Memória da Luma limpa nesta conversa!");
-        return true;
-      case COMMANDS.MY_NUMBER: {
-        const senderNum = await bot.getSenderNumber();
-        const chatId = bot.jid;
-        await bot.reply(
-          `📱 *Informações de ID*\n\n👤 *Seu Número:* ${senderNum}\n💬 *ID deste Chat:* ${chatId}`,
-        );
-        return true;
-      }
-      case COMMANDS.STICKER:
-      case COMMANDS.STICKER_SHORT:
-        await this.handleStickerCommand(bot, text);
-        return true;
-      case COMMANDS.IMAGE:
-      case COMMANDS.IMAGE_SHORT:
-        await this.handleImageCommand(bot);
-        return true;
-      case COMMANDS.GIF:
-      case COMMANDS.GIF_SHORT:
-        await this.handleGifCommand(bot);
-        return true;
-      case COMMANDS.DOWNLOAD: {
-        const url = this.extractUrl(text) || this.extractUrl(bot.quotedText);
-        if (url) {
-          await this.handleVideoDownload(bot, url);
-        } else {
-          await bot.reply(MESSAGES.VIDEO_NO_URL);
-        }
-        return true;
-      }
-      case COMMANDS.EVERYONE:
-        await bot.react("📢");
-        if (bot.isGroup) {
-          await GroupManager.mentionEveryone(bot.raw, bot.socket);
-        } else {
-          await bot.reply("⚠️ Este comando só funciona em grupos!");
-        }
-        return true;
-    }
-    return false;
-  }
-
-  /**
-   * Envia a mensagem do usuário para a Luma (IA) e despacha ferramentas se necessário.
-   * Salva o quotedBot ANTES de chamar a IA, pois o download de mídia muta o protobuf.
-   */
-  static async handleLumaCommand(bot, isReply = false, groupContext = "") {
-    try {
-      const senderName = bot.senderName;
-      let userMessage = isReply
-        ? bot.body
-        : this.lumaHandler.extractUserMessage(bot.body);
-
-      if (!userMessage && bot.hasVisualContent) {
-        if (bot.hasSticker) {
-          userMessage =
-            "[O usuário respondeu com uma figurinha/sticker. Analise a imagem visualmente, entenda a emoção dela e reaja ao contexto]";
-        } else {
-          userMessage = "[O usuário enviou uma imagem. Analise o conteúdo]";
-        }
-      }
-
-      if (!userMessage) {
-        const bored = this.lumaHandler.getRandomBoredResponse();
-        const sent = await bot.reply(bored);
-        if (sent?.key?.id) {
-          this.lumaHandler.saveLastBotMessage(bot.jid, sent.key.id);
-        }
-        return;
-      }
-
-      await bot.sendPresence("composing");
-      await this.randomDelay();
-
-      // Salva referência ao quoted ANTES da IA processar (protobuf é mutado no download)
-      const quotedBot = bot.getQuotedAdapter();
-
-      const response = await this.lumaHandler.generateResponse(
-        userMessage,
-        bot.jid,
-        bot.raw,
-        bot.socket,
-        senderName,
-        groupContext,
-      );
-
-      if (response.parts?.length > 0) {
-        const lastSent = await this._sendParts(bot, response.parts);
-        if (lastSent?.key?.id) {
-          this.lumaHandler.saveLastBotMessage(bot.jid, lastSent.key.id);
-        }
-      }
-
-      if (response.toolCalls && response.toolCalls.length > 0) {
-        await ToolDispatcher.handleToolCalls(bot, response.toolCalls, this.lumaHandler, quotedBot);
-      }
-    } catch (error) {
-      Logger.error("❌ Erro no comando da Luma:", error);
-      if (error.message?.includes("API_KEY")) {
-        await bot.reply("Tô sem cérebro (API Key inválida).");
-      }
-    }
-  }
-
-  // --- Comandos de Mídia ---
-
-  static async handleStickerCommand(bot, text) {
-    await bot.react("⏳");
-    const url = this.extractUrl(text);
-    if (url) {
-      await MediaProcessor.processUrlToSticker(url, bot.socket, bot.raw);
-      this.incrementMediaStats("stickers_created");
-      await bot.react("✅");
-      return;
-    }
-    if (bot.hasMedia) {
-      await MediaProcessor.processToSticker(bot.raw, bot.socket);
-      this.incrementMediaStats("stickers_created");
-      await bot.react("✅");
-      return;
-    }
-    const quoted = bot.getQuotedAdapter();
-    if (quoted?.hasVisualContent) {
-      await MediaProcessor.processToSticker(quoted.raw, bot.socket, bot.jid);
-      this.incrementMediaStats("stickers_created");
-      await bot.react("✅");
-    } else {
-      await bot.react("❌");
-      await bot.reply(MESSAGES.REPLY_MEDIA_STICKER);
-    }
-  }
-
-  static async handleImageCommand(bot) {
-    await bot.react("⏳");
-    if (bot.hasSticker) {
-      await MediaProcessor.processStickerToImage(bot.raw, bot.socket);
-      this.incrementMediaStats("images_created");
-      await bot.react("✅");
-      return;
-    }
-    const quoted = bot.getQuotedAdapter();
-    if (quoted?.hasSticker) {
-      await MediaProcessor.processStickerToImage(quoted.raw, bot.socket, bot.jid);
-      this.incrementMediaStats("images_created");
-      await bot.react("✅");
-    } else {
-      await bot.react("❌");
-      await bot.reply(MESSAGES.REPLY_STICKER_IMAGE);
-    }
-  }
-
-  static async handleGifCommand(bot) {
-    await bot.react("⏳");
-    if (bot.hasSticker) {
-      await MediaProcessor.processStickerToGif(bot.raw, bot.socket);
-      this.incrementMediaStats("gifs_created");
-      await bot.react("✅");
-      return;
-    }
-    const quoted = bot.getQuotedAdapter();
-    if (quoted?.hasSticker) {
-      await MediaProcessor.processStickerToGif(quoted.raw, bot.socket, bot.jid);
-      this.incrementMediaStats("gifs_created");
-      await bot.react("✅");
-    } else {
-      await bot.react("❌");
-      await bot.reply(MESSAGES.REPLY_STICKER_GIF);
-    }
-  }
-
-  // --- Menus e Estatísticas ---
-
-  static async sendStats(bot) {
-    const dbStats = DatabaseService.getMetrics();
-    const memoryStats = this.lumaHandler.getStats();
-
-    let statsText =
-      `📊 *Estatísticas Globais da Luma*\n\n` +
-      `🧠 *Inteligência Artificial:*\n` +
-      `• Respostas Geradas: ${dbStats.ai_responses || 0}\n` +
-      `• Conversas Ativas (RAM): ${memoryStats.totalConversations}\n`;
-
-    statsText +=
-      `\n🎨 *Mídia Gerada:*\n` +
-      `• Figurinhas: ${dbStats.stickers_created || 0}\n` +
-      `• Imagens: ${dbStats.images_created || 0}\n` +
-      `• GIFs: ${dbStats.gifs_created || 0}\n` +
-      `• Vídeos Baixados: ${dbStats.videos_downloaded || 0}\n\n` +
-      `📈 *Total de Interações:* ${dbStats.total_messages || 0}`;
-
-    await bot.sendText(statsText);
-  }
-
-  static async sendPersonalityMenu(bot) {
-    const list = PersonalityManager.getList();
-    const currentName = PersonalityManager.getActiveName(bot.jid);
-
-    let text = `${MENUS.PERSONALITY.HEADER}\n`;
-    text += `🔹 Atual neste chat: ${currentName}\n\n`;
-
-    list.forEach((p, index) => {
-      const isDefault =
-        p.key === LUMA_CONFIG.DEFAULT_PERSONALITY ? " ⭐ (Padrão)" : "";
-      text += `p${index + 1} - ${p.name}${isDefault}\n${p.desc}\n\n`;
-    });
-
-    text += MENUS.PERSONALITY.FOOTER;
-    await bot.sendText(text);
-  }
-
-  static async handleMenuReply(bot, text) {
+  static async _handleMenuReply(bot) {
     const quotedText = bot.quotedText;
-    if (!quotedText) return false;
-    if (quotedText.includes(MENUS.PERSONALITY.HEADER.split("\n")[0])) {
-      const list = PersonalityManager.getList();
-      const num = parseInt(text.trim().toLowerCase().replace("p", ""));
-      const index = !isNaN(num) && num > 0 ? num - 1 : -1;
-      if (index >= 0 && index < list.length) {
-        PersonalityManager.setPersonality(bot.jid, list[index].key);
-        await bot.reply(`${MENUS.MSGS.PERSONA_CHANGED}*${list[index].name}*`);
-      } else {
-        await bot.reply(MENUS.MSGS.INVALID_OPT);
-      }
-      return true;
+    if (!quotedText?.includes(MENUS.PERSONALITY.HEADER.split("\n")[0])) return false;
+
+    const list  = PersonalityManager.getList();
+    const num   = parseInt(bot.body.trim().toLowerCase().replace("p", ""));
+    const index = !isNaN(num) && num > 0 ? num - 1 : -1;
+
+    if (index >= 0 && index < list.length) {
+      PersonalityManager.setPersonality(bot.jid, list[index].key);
+      await bot.reply(`${MENUS.MSGS.PERSONA_CHANGED}*${list[index].name}*`);
+    } else {
+      await bot.reply(MENUS.MSGS.INVALID_OPT);
     }
-    return false;
+    return true;
   }
 
-  // --- Download de Vídeos Sociais ---
-
-  /**
-   * Baixa o vídeo de um link do Twitter/X ou Instagram via yt-dlp
-   * e envia na conversa como vídeo.
-   */
-  static async handleVideoDownload(bot, url) {
-    let filePath = null;
-    let convertedPath = null;
-    try {
-      await bot.react("⏳");
-      Logger.info(`🎬 Iniciando download de vídeo social: ${url}`);
-
-      filePath = await VideoDownloader.download(url);
-
-      Logger.info("🔄 Remuxando para compatibilidade com iOS...");
-      convertedPath = await VideoConverter.remuxForMobile(filePath);
-
-      const videoBuffer = fs.readFileSync(convertedPath);
-      await bot.socket.sendMessage(bot.jid, {
-        video: videoBuffer,
-        caption: MESSAGES.VIDEO_SENT,
-      });
-
-      Logger.info("✅ Vídeo social enviado com sucesso.");
-      DatabaseService.incrementMetric("videos_downloaded");
-      DatabaseService.incrementMetric("total_messages");
-      await bot.react("✅");
-    } catch (error) {
-      Logger.error("❌ Erro no download de vídeo social:", error.message);
-
-      if (error.message?.includes("yt-dlp") && error.message?.includes("not found")) {
-        await bot.reply(MESSAGES.YTDLP_NOT_FOUND);
-      } else if (error.message?.includes("File is larger")) {
-        await bot.reply(MESSAGES.VIDEO_TOO_LARGE);
-      } else {
-        await bot.reply(MESSAGES.VIDEO_DOWNLOAD_ERROR);
-      }
-
-      await bot.react("❌");
-    } finally {
-      for (const f of [filePath, convertedPath]) {
-        if (f) {
-          try { fs.unlinkSync(f); } catch (_) { /* ignora erro de limpeza */ }
-        }
-      }
-    }
-  }
-
-  // --- Utilitários ---
-
-  static detectCommand(text) {
-    const lower = text.toLowerCase();
-    if (lower === COMMANDS.MY_NUMBER) return COMMANDS.MY_NUMBER;
-    if (lower.includes(COMMANDS.LUMA_CLEAR)) return COMMANDS.LUMA_CLEAR;
-    // Aliases de luma clear: !lc e !clear — verificados ANTES de !clear para
-    // evitar que "!lc" seja parcialmente absorvido por outra checagem.
-    if (lower === COMMANDS.LUMA_CLEAR_SHORT) return COMMANDS.LUMA_CLEAR;
-    if (lower.includes("!clear")) return COMMANDS.LUMA_CLEAR_ALT;
-    if (lower.includes(COMMANDS.LUMA_STATS)) return COMMANDS.LUMA_STATS;
-    if (lower.includes(COMMANDS.LUMA_STATS_SHORT)) return COMMANDS.LUMA_STATS;
-    if (lower.includes(COMMANDS.STICKER)) return COMMANDS.STICKER;
-    if (lower.includes(COMMANDS.STICKER_SHORT)) return COMMANDS.STICKER;
-    if (lower.includes(COMMANDS.IMAGE)) return COMMANDS.IMAGE;
-    if (lower.includes(COMMANDS.IMAGE_SHORT)) return COMMANDS.IMAGE;
-    if (lower.includes(COMMANDS.GIF)) return COMMANDS.GIF;
-    if (lower.includes(COMMANDS.GIF_SHORT)) return COMMANDS.GIF;
-    if (lower.includes(COMMANDS.EVERYONE.toLowerCase()) || lower === "@todos")
-      return COMMANDS.EVERYONE;
-    if (lower.includes(COMMANDS.HELP) || lower === "!menu")
-      return COMMANDS.HELP;
-    if (lower.startsWith(COMMANDS.PERSONA)) return COMMANDS.PERSONA;
-    if (lower.startsWith(COMMANDS.DOWNLOAD)) return COMMANDS.DOWNLOAD;
-    if (lower.startsWith(COMMANDS.DOWNLOAD_SHORT)) return COMMANDS.DOWNLOAD;
-    return null;
-  }
-
-  static extractUrl(text) {
-    if (!text) return null;
-    const match = text.match(/(https?:\/\/[^\s]+)/g);
-    return match ? match[0] : null;
-  }
-
-  static incrementMediaStats(type) {
-    DatabaseService.incrementMetric(type);
-    DatabaseService.incrementMetric("total_messages");
-  }
-
-  static async randomDelay() {
-    const { min, max } = LUMA_CONFIG.TECHNICAL.thinkingDelay;
-    await new Promise((resolve) =>
-      setTimeout(resolve, min + Math.random() * (max - min)),
-    );
-  }
-
-  /** Usado pelo MediaProcessor para identificar o tipo da mídia. */
-  static getMessageType(message) {
-    if (message.message?.imageMessage)
-      return message.message.imageMessage.mimetype?.includes("gif")
-        ? "gif"
-        : "image";
-    if (message.message?.videoMessage)
-      return message.message.videoMessage.gifPlayback ? "gif" : "video";
-    return "image";
-  }
-
-  static async sendMessage(sock, jid, text) {
-    try {
-      if (sock) await sock.sendMessage(jid, { text });
-    } catch (error) {
-      Logger.error("Erro ao enviar:", error);
-    }
-  }
-
-  // --- Easter Eggs ---
-
-  /** @private */
   static async _handleEasterEggs(bot) {
-    await this.groupJoke(bot, "beta", "559884323093","120363203644262523@g.us");
+    await this._groupJoke(bot, "beta", "559884323093", "120363203644262523@g.us");
   }
 
-  static async groupJoke(bot, triggerWord, targetNumber, targetGroup) {
-    const text = bot.body;
-    const jid = bot.jid;
+  static async _groupJoke(bot, triggerWord, targetNumber, targetGroup) {
+    const { body: text, jid } = bot;
+    if (!bot.isGroup || jid !== targetGroup || !text) return;
 
-    if (bot.isGroup && jid === targetGroup && text) {
-      const regex = new RegExp(triggerWord, "gi");
-      const matches = text.match(regex);
-
-      if (matches && matches.length > 0) {
-        const mentionsArr = Array(matches.length).fill(`@${targetNumber}`);
-
-        await bot.socket.sendMessage(jid, {
-          text: mentionsArr.join(" "),
-          mentions: [`${targetNumber}@s.whatsapp.net`]
-        });
-      }
+    const matches = text.match(new RegExp(triggerWord, "gi"));
+    if (matches?.length > 0) {
+      await bot.socket.sendMessage(jid, {
+        text: Array(matches.length).fill(`@${targetNumber}`).join(" "),
+        mentions: [`${targetNumber}@s.whatsapp.net`],
+      });
     }
   }
 }

--- a/src/handlers/ToolDispatcher.js
+++ b/src/handlers/ToolDispatcher.js
@@ -1,9 +1,10 @@
 import { Logger } from "../utils/Logger.js";
 import { GroupManager } from "../managers/GroupManager.js";
 import { MediaProcessor } from "./MediaProcessor.js";
-import { MessageHandler } from "./MessageHandler.js";
+import { DatabaseService } from "../services/Database.js";
 import { PersonalityManager } from "../managers/PersonalityManager.js";
 import { MENUS } from "../config/constants.js";
+import { LUMA_CONFIG } from "../config/lumaConfig.js";
 
 /**
  * Despachante de ferramentas acionadas pela IA.
@@ -161,12 +162,12 @@ export class ToolDispatcher {
 
         if (bot.innerMessage?.imageMessage || bot.innerMessage?.videoMessage || bot.innerMessage?.stickerMessage) {
             await MediaProcessor.processToSticker(bot.raw, bot.socket);
-            MessageHandler.incrementMediaStats("stickers_created");
+            DatabaseService.incrementMetric("stickers_created");
             return;
         }
         if (quoted?.hasVisualContent) {
             await MediaProcessor.processToSticker(quoted.raw, bot.socket, bot.jid);
-            MessageHandler.incrementMediaStats("stickers_created");
+            DatabaseService.incrementMetric("stickers_created");
             return;
         }
         await bot.reply("⚠️ Você precisa responder a uma imagem, vídeo ou GIF para eu fazer a figurinha!");
@@ -177,12 +178,12 @@ export class ToolDispatcher {
 
         if (bot.innerMessage?.stickerMessage) {
             await MediaProcessor.processStickerToImage(bot.raw, bot.socket);
-            MessageHandler.incrementMediaStats("images_created");
+            DatabaseService.incrementMetric("images_created");
             return;
         }
         if (quoted?.hasSticker) {
             await MediaProcessor.processStickerToImage(quoted.raw, bot.socket, bot.jid);
-            MessageHandler.incrementMediaStats("images_created");
+            DatabaseService.incrementMetric("images_created");
             return;
         }
         await bot.reply("⚠️ Você precisa responder a uma figurinha (sticker) para eu transformar em imagem!");
@@ -193,12 +194,12 @@ export class ToolDispatcher {
 
         if (bot.innerMessage?.stickerMessage) {
             await MediaProcessor.processStickerToGif(bot.raw, bot.socket);
-            MessageHandler.incrementMediaStats("gifs_created");
+            DatabaseService.incrementMetric("gifs_created");
             return;
         }
         if (quoted?.hasSticker) {
             await MediaProcessor.processStickerToGif(quoted.raw, bot.socket, bot.jid);
-            MessageHandler.incrementMediaStats("gifs_created");
+            DatabaseService.incrementMetric("gifs_created");
             return;
         }
         await bot.reply("⚠️ Você precisa responder a uma figurinha animada para eu transformar em GIF!");
@@ -231,6 +232,18 @@ export class ToolDispatcher {
     }
 
     static async handleShowPersonalityMenu(bot) {
-        await MessageHandler.sendPersonalityMenu(bot);
+        const list        = PersonalityManager.getList();
+        const currentName = PersonalityManager.getActiveName(bot.jid);
+
+        let text = `${MENUS.PERSONALITY.HEADER}\n`;
+        text += `🔹 Atual neste chat: ${currentName}\n\n`;
+
+        list.forEach((p, i) => {
+            const isDefault = p.key === LUMA_CONFIG.DEFAULT_PERSONALITY ? " ⭐ (Padrão)" : "";
+            text += `p${i + 1} - ${p.name}${isDefault}\n${p.desc}\n\n`;
+        });
+
+        text += MENUS.PERSONALITY.FOOTER;
+        await bot.sendText(text);
     }
 }

--- a/src/managers/GroupManager.js
+++ b/src/managers/GroupManager.js
@@ -1,5 +1,4 @@
 import { Logger } from "../utils/Logger.js";
-import { MessageHandler } from "../handlers/MessageHandler.js";
 
 export class GroupManager {
   static async mentionEveryone(message, sock) {
@@ -7,11 +6,7 @@ export class GroupManager {
       const jid = message.key.remoteJid;
 
       if (!jid.endsWith("@g.us")) {
-        await MessageHandler.sendMessage(
-          sock,
-          jid,
-          "⚠️ Este comando só funciona em grupos!"
-        );
+        await sock.sendMessage(jid, { text: "⚠️ Este comando só funciona em grupos!" });
         return;
       }
 
@@ -22,31 +17,18 @@ export class GroupManager {
       const isAdmin = participants.find((p) => p.id === sender)?.admin;
 
       if (!isAdmin) {
-        await MessageHandler.sendMessage(
-          sock,
-          jid,
-          "⚠️ Apenas administradores podem usar este comando!"
-        );
+        await sock.sendMessage(jid, { text: "⚠️ Apenas administradores podem usar este comando!" });
         return;
       }
 
       const mentions = participants.map((p) => p.id);
-
       const text = participants.map((p) => `@${p.id.split("@")[0]}`).join(" ");
 
-      await sock.sendMessage(jid, {
-        text: `📢 *Atenção geral!*\n\n${text}`,
-        mentions: mentions,
-      });
-
+      await sock.sendMessage(jid, { text: `📢 *Atenção geral!*\n\n${text}`, mentions });
       Logger.info(`✅ Mencionados ${participants.length} participantes`);
     } catch (error) {
       Logger.error("Erro ao mencionar todos:", error);
-      await MessageHandler.sendMessage(
-        sock,
-        message.key.remoteJid,
-        "❌ Erro ao mencionar participantes"
-      );
+      await sock.sendMessage(message.key.remoteJid, { text: "❌ Erro ao mencionar participantes" }).catch(() => {});
     }
   }
 }

--- a/src/utils/MessageUtils.js
+++ b/src/utils/MessageUtils.js
@@ -1,0 +1,30 @@
+/**
+ * Utilitários puros para análise de mensagens do WhatsApp.
+ * Sem dependências de handlers — pode ser importado por qualquer módulo.
+ */
+
+/**
+ * Determina o tipo de mídia de uma mensagem Baileys.
+ * @param {object} message - Objeto de mensagem raw do Baileys
+ * @returns {'image'|'gif'|'video'} Tipo da mídia
+ */
+export function getMessageType(message) {
+  if (message.message?.imageMessage) {
+    return message.message.imageMessage.mimetype?.includes("gif") ? "gif" : "image";
+  }
+  if (message.message?.videoMessage) {
+    return message.message.videoMessage.gifPlayback ? "gif" : "video";
+  }
+  return "image";
+}
+
+/**
+ * Extrai a primeira URL encontrada num texto.
+ * @param {string|null} text
+ * @returns {string|null}
+ */
+export function extractUrl(text) {
+  if (!text) return null;
+  const match = text.match(/(https?:\/\/[^\s]+)/g);
+  return match ? match[0] : null;
+}

--- a/tests/unit/MessageHandler.test.js
+++ b/tests/unit/MessageHandler.test.js
@@ -1,18 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
 
 /**
- * Testes de caracterização das funções puras do MessageHandler.
+ * Testes de caracterização do MessageHandler.
  *
- * Apenas as funções determinísticas são testadas aqui:
- * - detectCommand: parsing de comandos com prefixo
- * - extractUrl: extração de URLs de texto
- * - getMessageType: detecção de tipo de mídia
+ * As funções puras detectCommand, extractUrl e getMessageType foram
+ * movidas respectivamente para:
+ *   - CommandRouter.detect  → tests/unit/core/services/CommandRouter.test.js
+ *   - MessageUtils.extractUrl    → tests/unit/utils/MessageUtils.test.js
+ *   - MessageUtils.getMessageType → tests/unit/utils/MessageUtils.test.js
  *
- * O fluxo completo (process, handleLumaCommand) pertence aos testes
- * de integração, pois envolve socket real + IA.
+ * Este arquivo mantém os testes usando os novos locais para evitar regressão.
  */
 
-// Isola as dependências com efeitos colaterais do MessageHandler
 vi.mock('../../src/services/AIService.js', () => ({
   AIService: vi.fn().mockImplementation(() => ({
     generateContent: vi.fn(),
@@ -52,160 +51,157 @@ vi.mock('../../src/handlers/SpontaneousHandler.js', () => ({
   SpontaneousHandler: { handle: vi.fn(), trackActivity: vi.fn() },
 }));
 
-import { MessageHandler } from '../../src/handlers/MessageHandler.js';
 import { COMMANDS } from '../../src/config/constants.js';
+import { CommandRouter } from '../../src/core/services/CommandRouter.js';
+import { getMessageType, extractUrl } from '../../src/utils/MessageUtils.js';
 
-describe('MessageHandler.detectCommand — detecção de comandos', () => {
+describe('CommandRouter.detect — detecção de comandos (via MessageHandler.test)', () => {
   it('detecta !sticker', () => {
-    expect(MessageHandler.detectCommand('!sticker')).toBe(COMMANDS.STICKER);
+    expect(CommandRouter.detect('!sticker')).toBe(COMMANDS.STICKER);
   });
 
   it('detecta !s (alias do sticker)', () => {
-    expect(MessageHandler.detectCommand('!s')).toBe(COMMANDS.STICKER);
+    expect(CommandRouter.detect('!s')).toBe(COMMANDS.STICKER);
   });
 
   it('detecta !image', () => {
-    expect(MessageHandler.detectCommand('!image')).toBe(COMMANDS.IMAGE);
+    expect(CommandRouter.detect('!image')).toBe(COMMANDS.IMAGE);
   });
 
   it('detecta !i (alias do image)', () => {
-    expect(MessageHandler.detectCommand('!i')).toBe(COMMANDS.IMAGE);
+    expect(CommandRouter.detect('!i')).toBe(COMMANDS.IMAGE);
   });
 
   it('detecta !gif', () => {
-    expect(MessageHandler.detectCommand('!gif')).toBe(COMMANDS.GIF);
+    expect(CommandRouter.detect('!gif')).toBe(COMMANDS.GIF);
   });
 
   it('detecta !g (alias do gif)', () => {
-    expect(MessageHandler.detectCommand('!g')).toBe(COMMANDS.GIF);
+    expect(CommandRouter.detect('!g')).toBe(COMMANDS.GIF);
   });
 
   it('detecta !help', () => {
-    expect(MessageHandler.detectCommand('!help')).toBe(COMMANDS.HELP);
+    expect(CommandRouter.detect('!help')).toBe(COMMANDS.HELP);
   });
 
   it('detecta !menu como alias do help', () => {
-    expect(MessageHandler.detectCommand('!menu')).toBe(COMMANDS.HELP);
+    expect(CommandRouter.detect('!menu')).toBe(COMMANDS.HELP);
   });
 
   it('detecta !persona', () => {
-    expect(MessageHandler.detectCommand('!persona')).toBe(COMMANDS.PERSONA);
+    expect(CommandRouter.detect('!persona')).toBe(COMMANDS.PERSONA);
   });
 
   it('detecta !download com URL', () => {
-    expect(MessageHandler.detectCommand('!download https://x.com/algo')).toBe(COMMANDS.DOWNLOAD);
+    expect(CommandRouter.detect('!download https://x.com/algo')).toBe(COMMANDS.DOWNLOAD);
   });
 
   it('detecta !d (alias do download)', () => {
-    expect(MessageHandler.detectCommand('!d https://x.com/algo')).toBe(COMMANDS.DOWNLOAD);
+    expect(CommandRouter.detect('!d https://x.com/algo')).toBe(COMMANDS.DOWNLOAD);
   });
 
   it('detecta @everyone', () => {
-    expect(MessageHandler.detectCommand('@everyone')).toBe(COMMANDS.EVERYONE);
+    expect(CommandRouter.detect('@everyone')).toBe(COMMANDS.EVERYONE);
   });
 
   it('detecta @todos (alias do everyone)', () => {
-    expect(MessageHandler.detectCommand('@todos')).toBe(COMMANDS.EVERYONE);
+    expect(CommandRouter.detect('@todos')).toBe(COMMANDS.EVERYONE);
   });
 
   it('detecta !luma stats', () => {
-    expect(MessageHandler.detectCommand('!luma stats')).toBe(COMMANDS.LUMA_STATS);
+    expect(CommandRouter.detect('!luma stats')).toBe(COMMANDS.LUMA_STATS);
   });
 
   it('detecta !ls (alias do luma stats)', () => {
-    expect(MessageHandler.detectCommand('!ls')).toBe(COMMANDS.LUMA_STATS);
+    expect(CommandRouter.detect('!ls')).toBe(COMMANDS.LUMA_STATS);
   });
 
   it('detecta !luma clear', () => {
-    expect(MessageHandler.detectCommand('!luma clear')).toBe(COMMANDS.LUMA_CLEAR);
+    expect(CommandRouter.detect('!luma clear')).toBe(COMMANDS.LUMA_CLEAR);
   });
 
   it('detecta !lc (alias do luma clear)', () => {
-    expect(MessageHandler.detectCommand('!lc')).toBe(COMMANDS.LUMA_CLEAR);
+    expect(CommandRouter.detect('!lc')).toBe(COMMANDS.LUMA_CLEAR);
   });
 
   it('detecta !clear (alias alternativo do luma clear)', () => {
-    expect(MessageHandler.detectCommand('!clear')).toBe(COMMANDS.LUMA_CLEAR_ALT);
+    expect(CommandRouter.detect('!clear')).toBe(COMMANDS.LUMA_CLEAR_ALT);
   });
 
   it('detecta !meunumero', () => {
-    expect(MessageHandler.detectCommand('!meunumero')).toBe(COMMANDS.MY_NUMBER);
+    expect(CommandRouter.detect('!meunumero')).toBe(COMMANDS.MY_NUMBER);
   });
 
   it('é case insensitive — !STICKER detecta como sticker', () => {
-    expect(MessageHandler.detectCommand('!STICKER')).toBe(COMMANDS.STICKER);
+    expect(CommandRouter.detect('!STICKER')).toBe(COMMANDS.STICKER);
   });
 
   it('retorna null para texto sem comando', () => {
-    expect(MessageHandler.detectCommand('oi tudo bem?')).toBeNull();
+    expect(CommandRouter.detect('oi tudo bem?')).toBeNull();
   });
 
   it('retorna null para string vazia', () => {
-    expect(MessageHandler.detectCommand('')).toBeNull();
+    expect(CommandRouter.detect('')).toBeNull();
   });
 
   it('retorna null para mensagem da Luma sem prefixo de comando', () => {
-    expect(MessageHandler.detectCommand('luma me explica isso')).toBeNull();
+    expect(CommandRouter.detect('luma me explica isso')).toBeNull();
   });
 });
 
-describe('MessageHandler.extractUrl — extração de URLs', () => {
+describe('extractUrl — extração de URLs', () => {
   it('extrai URL https de texto simples', () => {
-    const url = MessageHandler.extractUrl('!download https://x.com/user/status/123');
-    expect(url).toBe('https://x.com/user/status/123');
+    expect(extractUrl('!download https://x.com/user/status/123')).toBe('https://x.com/user/status/123');
   });
 
   it('extrai URL http também', () => {
-    const url = MessageHandler.extractUrl('veja em http://exemplo.com/pagina');
-    expect(url).toBe('http://exemplo.com/pagina');
+    expect(extractUrl('veja em http://exemplo.com/pagina')).toBe('http://exemplo.com/pagina');
   });
 
   it('extrai a primeira URL quando há múltiplas', () => {
-    const url = MessageHandler.extractUrl('veja https://primeiro.com e https://segundo.com');
-    expect(url).toBe('https://primeiro.com');
+    expect(extractUrl('veja https://primeiro.com e https://segundo.com')).toBe('https://primeiro.com');
   });
 
   it('retorna null para texto sem URL', () => {
-    expect(MessageHandler.extractUrl('texto sem link nenhum')).toBeNull();
+    expect(extractUrl('texto sem link nenhum')).toBeNull();
   });
 
   it('retorna null para null', () => {
-    expect(MessageHandler.extractUrl(null)).toBeNull();
+    expect(extractUrl(null)).toBeNull();
   });
 
   it('retorna null para string vazia', () => {
-    expect(MessageHandler.extractUrl('')).toBeNull();
+    expect(extractUrl('')).toBeNull();
   });
 
   it('extrai URL do Instagram corretamente', () => {
-    const url = MessageHandler.extractUrl('!d https://instagram.com/reel/abc123/');
-    expect(url).toBe('https://instagram.com/reel/abc123/');
+    expect(extractUrl('!d https://instagram.com/reel/abc123/')).toBe('https://instagram.com/reel/abc123/');
   });
 });
 
-describe('MessageHandler.getMessageType — detecção de tipo de mídia', () => {
+describe('getMessageType — detecção de tipo de mídia', () => {
   it('retorna "image" para imageMessage sem gif', () => {
     const msg = { message: { imageMessage: { mimetype: 'image/jpeg' } } };
-    expect(MessageHandler.getMessageType(msg)).toBe('image');
+    expect(getMessageType(msg)).toBe('image');
   });
 
   it('retorna "gif" para imageMessage com mimetype gif', () => {
     const msg = { message: { imageMessage: { mimetype: 'image/gif' } } };
-    expect(MessageHandler.getMessageType(msg)).toBe('gif');
+    expect(getMessageType(msg)).toBe('gif');
   });
 
   it('retorna "video" para videoMessage sem gifPlayback', () => {
     const msg = { message: { videoMessage: { gifPlayback: false } } };
-    expect(MessageHandler.getMessageType(msg)).toBe('video');
+    expect(getMessageType(msg)).toBe('video');
   });
 
   it('retorna "gif" para videoMessage com gifPlayback true', () => {
     const msg = { message: { videoMessage: { gifPlayback: true } } };
-    expect(MessageHandler.getMessageType(msg)).toBe('gif');
+    expect(getMessageType(msg)).toBe('gif');
   });
 
   it('retorna "image" como fallback para tipos desconhecidos', () => {
     const msg = { message: { stickerMessage: {} } };
-    expect(MessageHandler.getMessageType(msg)).toBe('image');
+    expect(getMessageType(msg)).toBe('image');
   });
 });

--- a/tests/unit/core/services/CommandRouter.test.js
+++ b/tests/unit/core/services/CommandRouter.test.js
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mocks de todos os módulos que CommandRouter importa
+vi.mock('../../../../src/handlers/MediaProcessor.js', () => ({
+  MediaProcessor: { processToSticker: vi.fn(), processStickerToImage: vi.fn(), processStickerToGif: vi.fn(), processUrlToSticker: vi.fn(), downloadMedia: vi.fn() },
+}));
+
+vi.mock('../../../../src/managers/GroupManager.js', () => ({
+  GroupManager: { mentionEveryone: vi.fn() },
+}));
+
+vi.mock('../../../../src/services/VideoDownloader.js', () => ({
+  VideoDownloader: { download: vi.fn(), detectVideoUrl: vi.fn() },
+}));
+
+vi.mock('../../../../src/processors/VideoConverter.js', () => ({
+  VideoConverter: { remuxForMobile: vi.fn(), toSticker: vi.fn(), toGif: vi.fn(), toMp4: vi.fn() },
+}));
+
+vi.mock('../../../../src/services/Database.js', () => ({
+  DatabaseService: { incrementMetric: vi.fn(), getMetrics: vi.fn().mockReturnValue({}) },
+}));
+
+vi.mock('../../../../src/managers/PersonalityManager.js', () => ({
+  PersonalityManager: {
+    getList: vi.fn().mockReturnValue([{ key: 'default', name: 'Luma', desc: 'Assistente' }]),
+    getActiveName: vi.fn().mockReturnValue('Luma'),
+    setPersonality: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../src/config/lumaConfig.js', () => ({
+  LUMA_CONFIG: { DEFAULT_PERSONALITY: 'default' },
+}));
+
+vi.mock('fs', () => ({
+  default: { readFileSync: vi.fn().mockReturnValue(Buffer.from('')), unlinkSync: vi.fn() },
+}));
+
+const { CommandRouter } = await import('../../../../src/core/services/CommandRouter.js');
+
+// Helper para criar bot mock
+function makeBot(overrides = {}) {
+  return {
+    jid: '123@s.whatsapp.net',
+    body: '',
+    quotedText: null,
+    isGroup: false,
+    isFromMe: false,
+    hasMedia: false,
+    hasSticker: false,
+    hasVisualContent: false,
+    raw: { key: { remoteJid: '123@s.whatsapp.net' } },
+    socket: { sendMessage: vi.fn(), groupMetadata: vi.fn() },
+    reply: vi.fn().mockResolvedValue({ key: { id: 'msg1' } }),
+    sendText: vi.fn().mockResolvedValue({}),
+    react: vi.fn().mockResolvedValue({}),
+    getQuotedAdapter: vi.fn().mockReturnValue(null),
+    getSenderNumber: vi.fn().mockResolvedValue('5511999999999'),
+    ...overrides,
+  };
+}
+
+describe('CommandRouter.detect — comandos', () => {
+  it.each([
+    ['!sticker',      '!sticker'],
+    ['!s',            '!sticker'],
+    ['!image',        '!image'],
+    ['!i',            '!image'],
+    ['!gif',          '!gif'],
+    ['!g',            '!gif'],
+    ['!help',         '!help'],
+    ['!menu',         '!help'],
+    ['!persona',      '!persona'],
+    ['!download url', '!download'],
+    ['!d url',        '!download'],
+    ['!luma clear',   '!luma clear'],
+    ['!lc',           '!luma clear'],
+    ['!clear',        '!clear'],
+    ['!luma stats',   '!luma stats'],
+    ['!ls',           '!luma stats'],
+    ['!meunumero',    '!meunumero'],
+    ['@everyone',     '@everyone'],
+    ['@todos',        '@everyone'],
+  ])('detecta "%s" como "%s"', (input, expected) => {
+    expect(CommandRouter.detect(input)).toBe(expected);
+  });
+
+  it('retorna null para texto sem comando', () => {
+    expect(CommandRouter.detect('oi luma tudo bem?')).toBeNull();
+  });
+
+  it('retorna null para null', () => {
+    expect(CommandRouter.detect(null)).toBeNull();
+  });
+
+  it('retorna null para string vazia', () => {
+    expect(CommandRouter.detect('')).toBeNull();
+  });
+
+  it('é case-insensitive', () => {
+    expect(CommandRouter.detect('!STICKER')).toBe('!sticker');
+    expect(CommandRouter.detect('!Help')).toBe('!help');
+  });
+});
+
+describe('CommandRouter.dispatch — !help', () => {
+  it('envia o texto do menu de ajuda', async () => {
+    const bot = makeBot({ body: '!help' });
+    const handled = await CommandRouter.dispatch(bot, '!help');
+    expect(handled).toBe(true);
+    expect(bot.sendText).toHaveBeenCalled();
+  });
+});
+
+describe('CommandRouter.dispatch — !luma clear', () => {
+  it('chama clearHistory no lumaHandler e responde', async () => {
+    const bot = makeBot({ body: '!lc' });
+    const lumaHandler = { clearHistory: vi.fn() };
+
+    const handled = await CommandRouter.dispatch(bot, '!luma clear', { lumaHandler });
+    expect(handled).toBe(true);
+    expect(lumaHandler.clearHistory).toHaveBeenCalledWith(bot.jid);
+    expect(bot.reply).toHaveBeenCalledWith(expect.stringContaining('limpa'));
+  });
+
+  it('não lança erro se lumaHandler não for passado', async () => {
+    const bot = makeBot();
+    await expect(CommandRouter.dispatch(bot, '!luma clear')).resolves.toBe(true);
+  });
+});
+
+describe('CommandRouter.dispatch — !meunumero', () => {
+  it('responde com o número e ID do chat', async () => {
+    const bot = makeBot();
+    const handled = await CommandRouter.dispatch(bot, '!meunumero');
+    expect(handled).toBe(true);
+    expect(bot.reply).toHaveBeenCalledWith(expect.stringContaining('Seu Número'));
+  });
+});
+
+describe('CommandRouter.dispatch — !persona', () => {
+  it('envia o menu de personalidades', async () => {
+    const bot = makeBot();
+    const handled = await CommandRouter.dispatch(bot, '!persona');
+    expect(handled).toBe(true);
+    expect(bot.sendText).toHaveBeenCalled();
+  });
+});
+
+describe('CommandRouter.dispatch — !luma stats', () => {
+  it('envia estatísticas', async () => {
+    const bot = makeBot();
+    const lumaHandler = { getStats: vi.fn().mockReturnValue({ totalConversations: 5 }) };
+    const handled = await CommandRouter.dispatch(bot, '!luma stats', { lumaHandler });
+    expect(handled).toBe(true);
+    expect(bot.sendText).toHaveBeenCalledWith(expect.stringContaining('Estatísticas'));
+  });
+});
+
+describe('CommandRouter.dispatch — !download', () => {
+  it('responde com mensagem de sem URL quando não encontra URL', async () => {
+    const bot = makeBot({ body: '!download', quotedText: null });
+    const handled = await CommandRouter.dispatch(bot, '!download');
+    expect(handled).toBe(true);
+    expect(bot.reply).toHaveBeenCalled();
+  });
+});
+
+describe('CommandRouter.dispatch — @everyone', () => {
+  it('reage com 📢 e avisa que só funciona em grupos quando em PV', async () => {
+    const bot = makeBot({ isGroup: false });
+    await CommandRouter.dispatch(bot, '@everyone');
+    expect(bot.react).toHaveBeenCalledWith('📢');
+    expect(bot.reply).toHaveBeenCalledWith(expect.stringContaining('grupos'));
+  });
+
+  it('chama GroupManager.mentionEveryone quando em grupo', async () => {
+    const { GroupManager } = await import('../../../../src/managers/GroupManager.js');
+    const bot = makeBot({ isGroup: true });
+    await CommandRouter.dispatch(bot, '@everyone');
+    expect(GroupManager.mentionEveryone).toHaveBeenCalled();
+  });
+});
+
+describe('CommandRouter.dispatch — comando desconhecido', () => {
+  it('retorna false para comando não registrado', async () => {
+    const bot = makeBot();
+    const handled = await CommandRouter.dispatch(bot, '!naoexiste');
+    expect(handled).toBe(false);
+  });
+});

--- a/tests/unit/core/services/GroupService.test.js
+++ b/tests/unit/core/services/GroupService.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GroupService } from '../../../../src/core/services/GroupService.js';
+
+function makeParticipants(withAdmin = true) {
+  return [
+    { id: '111@s.whatsapp.net', admin: withAdmin ? 'admin' : null },
+    { id: '222@s.whatsapp.net', admin: null },
+    { id: '333@s.whatsapp.net', admin: null },
+  ];
+}
+
+function makeBot(overrides = {}) {
+  return {
+    jid: 'group@g.us',
+    isGroup: true,
+    raw: { key: { remoteJid: 'group@g.us' }, participant: '111@s.whatsapp.net' },
+    socket: {
+      groupMetadata: vi.fn().mockResolvedValue({ participants: makeParticipants() }),
+      sendMessage: vi.fn().mockResolvedValue({}),
+    },
+    reply: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  };
+}
+
+describe('GroupService.mentionAll', () => {
+  it('avisa que só funciona em grupos quando em PV', async () => {
+    const bot = makeBot({ isGroup: false });
+    await GroupService.mentionAll(bot);
+    expect(bot.reply).toHaveBeenCalledWith(expect.stringContaining('grupos'));
+    expect(bot.socket.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('avisa que apenas admins podem usar o comando', async () => {
+    const bot = makeBot();
+    // Participante sender não é admin
+    bot.raw.participant = '222@s.whatsapp.net';
+    bot.socket.groupMetadata.mockResolvedValue({ participants: makeParticipants(false) });
+
+    await GroupService.mentionAll(bot);
+    expect(bot.reply).toHaveBeenCalledWith(expect.stringContaining('administradores'));
+  });
+
+  it('menciona todos os participantes quando sender é admin', async () => {
+    const bot = makeBot();
+    await GroupService.mentionAll(bot);
+
+    expect(bot.socket.sendMessage).toHaveBeenCalledWith(
+      bot.jid,
+      expect.objectContaining({
+        text: expect.stringContaining('Atenção geral'),
+        mentions: expect.arrayContaining(['111@s.whatsapp.net']),
+      }),
+    );
+  });
+
+  it('trata erro de groupMetadata com reply de erro', async () => {
+    const bot = makeBot();
+    bot.socket.groupMetadata.mockRejectedValue(new Error('falha de rede'));
+
+    await GroupService.mentionAll(bot);
+    expect(bot.reply).toHaveBeenCalledWith(expect.stringContaining('Erro'));
+  });
+});
+
+describe('GroupService.isAdmin', () => {
+  it('retorna true quando participante é admin', async () => {
+    const sock = {
+      groupMetadata: vi.fn().mockResolvedValue({ participants: makeParticipants(true) }),
+    };
+    const result = await GroupService.isAdmin(sock, 'group@g.us', '111@s.whatsapp.net');
+    expect(result).toBe(true);
+  });
+
+  it('retorna false quando participante não é admin', async () => {
+    const sock = {
+      groupMetadata: vi.fn().mockResolvedValue({ participants: makeParticipants(true) }),
+    };
+    const result = await GroupService.isAdmin(sock, 'group@g.us', '222@s.whatsapp.net');
+    expect(result).toBe(false);
+  });
+
+  it('retorna false quando participante não existe no grupo', async () => {
+    const sock = {
+      groupMetadata: vi.fn().mockResolvedValue({ participants: makeParticipants() }),
+    };
+    const result = await GroupService.isAdmin(sock, 'group@g.us', 'naoexiste@s.whatsapp.net');
+    expect(result).toBe(false);
+  });
+
+  it('retorna false em caso de erro', async () => {
+    const sock = {
+      groupMetadata: vi.fn().mockRejectedValue(new Error('erro')),
+    };
+    const result = await GroupService.isAdmin(sock, 'group@g.us', '111@s.whatsapp.net');
+    expect(result).toBe(false);
+  });
+});

--- a/tests/unit/utils/MessageUtils.test.js
+++ b/tests/unit/utils/MessageUtils.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { getMessageType, extractUrl } from '../../../src/utils/MessageUtils.js';
+
+describe('getMessageType', () => {
+  it('retorna "image" para imageMessage sem GIF', () => {
+    const msg = { message: { imageMessage: { mimetype: 'image/jpeg' } } };
+    expect(getMessageType(msg)).toBe('image');
+  });
+
+  it('retorna "gif" para imageMessage com mimetype gif', () => {
+    const msg = { message: { imageMessage: { mimetype: 'image/gif' } } };
+    expect(getMessageType(msg)).toBe('gif');
+  });
+
+  it('retorna "video" para videoMessage sem gifPlayback', () => {
+    const msg = { message: { videoMessage: { gifPlayback: false } } };
+    expect(getMessageType(msg)).toBe('video');
+  });
+
+  it('retorna "gif" para videoMessage com gifPlayback', () => {
+    const msg = { message: { videoMessage: { gifPlayback: true } } };
+    expect(getMessageType(msg)).toBe('gif');
+  });
+
+  it('retorna "image" como fallback para tipos desconhecidos', () => {
+    const msg = { message: { stickerMessage: {} } };
+    expect(getMessageType(msg)).toBe('image');
+  });
+});
+
+describe('extractUrl', () => {
+  it('extrai URL de um texto com URL', () => {
+    expect(extractUrl('Confira https://example.com/video')).toBe('https://example.com/video');
+  });
+
+  it('extrai apenas a primeira URL quando há múltiplas', () => {
+    expect(extractUrl('https://a.com e https://b.com')).toBe('https://a.com');
+  });
+
+  it('retorna null para texto sem URL', () => {
+    expect(extractUrl('sem url aqui')).toBeNull();
+  });
+
+  it('retorna null para null', () => {
+    expect(extractUrl(null)).toBeNull();
+  });
+
+  it('retorna null para string vazia', () => {
+    expect(extractUrl('')).toBeNull();
+  });
+
+  it('extrai URLs com http', () => {
+    expect(extractUrl('http://insecure.com')).toBe('http://insecure.com');
+  });
+});


### PR DESCRIPTION
## Summary

- **CommandRouter**: extrai toda lógica de detecção e dispatch de comandos (`!sticker`, `@everyone`, `!download`, etc.) para `src/core/services/CommandRouter.js`
- **GroupService**: novo serviço para operações de grupo (`mentionAll`, `isAdmin`) sem dependência de handlers
- **MessageUtils**: extrai `getMessageType` e `extractUrl` para `src/utils/MessageUtils.js`, quebrando a dependência circular `MediaProcessor ↔ MessageHandler`
- **ToolDispatcher**: remove import de `MessageHandler` — usa `DatabaseService` e `PersonalityManager` diretamente, quebrando o ciclo `LumaHandler → ToolDispatcher → MessageHandler → LumaHandler`
- **LumaHandler**: absorve `handle()`, `handleAudio()`, `_sendParts()` e `_dispatchResponse()` (antes em MessageHandler)
- **MessageHandler**: reduzido a orquestrador de ~120 linhas — apenas coordena fluxo, delega tudo para serviços

## Test plan

- [x] 340 testes passando (19 suites)
- [x] Novos testes: `CommandRouter.test.js`, `GroupService.test.js`, `MessageUtils.test.js`
- [x] `MessageHandler.test.js` atualizado para usar `CommandRouter.detect` e `MessageUtils`
- [x] Sem dependências circulares no grafo de imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)