### PR TITLE
feat(phase-5): multi-provider de IA via AI_PROVIDER — Gemini e OpenAI intercambiáveis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "node-webpmux": "^3.2.1",
+        "openai": "^6.34.0",
         "pino": "^10.0.0",
         "qrcode": "^1.5.4",
         "qrcode-terminal": "^0.12.0",
@@ -3102,6 +3103,27 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
+      "integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "node-webpmux": "^3.2.1",
+    "openai": "^6.34.0",
     "pino": "^10.0.0",
     "qrcode": "^1.5.4",
     "qrcode-terminal": "^0.12.0",

--- a/src/adapters/ai/OpenAIAdapter.js
+++ b/src/adapters/ai/OpenAIAdapter.js
@@ -1,0 +1,119 @@
+import OpenAI from "openai";
+import { AIPort } from "../../core/ports/AIPort.js";
+import { Logger } from "../../utils/Logger.js";
+
+/**
+ * Implementação de AIPort para a OpenAI (GPT-4o, GPT-4o-mini, etc.).
+ * Mapeia o formato interno de histórico (Gemini-style) para o formato Messages da OpenAI.
+ */
+export class OpenAIAdapter extends AIPort {
+  #client;
+  #model;
+  #stats = { calls: 0, tokensIn: 0, tokensOut: 0 };
+
+  /**
+   * @param {object} options
+   * @param {string} options.apiKey  - Chave da API da OpenAI
+   * @param {string} [options.model] - Modelo a usar (padrão: gpt-4o-mini)
+   */
+  constructor({ apiKey, model = "gpt-4o-mini" } = {}) {
+    super();
+    if (!apiKey) throw new Error("OpenAIAdapter: apiKey é obrigatória.");
+    this.#client = new OpenAI({ apiKey });
+    this.#model  = model;
+  }
+
+  /**
+   * Gera uma resposta com base no histórico de conversa e prompt de sistema.
+   *
+   * @param {Array<{role: string, parts: Array<{text: string}>}>} history - Histórico no formato interno
+   * @param {string} systemPrompt - Prompt de sistema (personalidade/instruções da Luma)
+   * @param {Array}  [tools=[]]   - Definições de ferramentas no formato Gemini (convertidas internamente)
+   * @returns {Promise<{text: string, functionCalls: Array<{name:string, args:object}>}>}
+   */
+  async generateContent(history, systemPrompt, tools = []) {
+    const messages = [
+      { role: "system", content: systemPrompt },
+      ...history.map(({ role, parts }) => ({
+        role: role === "model" ? "assistant" : "user",
+        content: parts.map((p) => p.text ?? "").join(""),
+      })),
+    ];
+
+    Logger.info(`🤖 OpenAI (${this.#model}) — ${messages.length} mensagens`);
+
+    const response = await this.#client.chat.completions.create({
+      model: this.#model,
+      messages,
+      tools: tools.length > 0 ? this.#convertTools(tools) : undefined,
+    });
+
+    this.#stats.calls++;
+    this.#stats.tokensIn  += response.usage?.prompt_tokens     ?? 0;
+    this.#stats.tokensOut += response.usage?.completion_tokens ?? 0;
+
+    const choice        = response.choices[0];
+    const text          = choice.message?.content ?? "";
+    const functionCalls = (choice.message?.tool_calls ?? []).map((tc) => ({
+      name: tc.function.name,
+      args: JSON.parse(tc.function.arguments),
+    }));
+
+    return { text, functionCalls };
+  }
+
+  /**
+   * Processa mídia (imagens) junto com um prompt de texto.
+   * Usa o formato multimodal de content array da OpenAI.
+   *
+   * @param {string} prompt
+   * @param {Array<{mimeType: string, data: Buffer}>} media
+   * @returns {Promise<string>}
+   */
+  async processMedia(prompt, media = []) {
+    const content = [
+      { type: "text", text: prompt },
+      ...media.map((m) => ({
+        type: "image_url",
+        image_url: {
+          url: `data:${m.mimeType};base64,${m.data.toString("base64")}`,
+        },
+      })),
+    ];
+
+    const response = await this.#client.chat.completions.create({
+      model: this.#model,
+      messages: [{ role: "user", content }],
+    });
+
+    return response.choices[0]?.message?.content ?? "";
+  }
+
+  /**
+   * Retorna estatísticas de uso (chamadas, tokens in/out).
+   * @returns {{ calls: number, tokensIn: number, tokensOut: number }}
+   */
+  getStats() {
+    return { ...this.#stats };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Privado
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Converte definições de tools do formato Gemini para o formato OpenAI.
+   * @param {Array} geminiTools
+   * @returns {Array}
+   */
+  #convertTools(geminiTools) {
+    return geminiTools.map((tool) => ({
+      type: "function",
+      function: {
+        name:        tool.name,
+        description: tool.description,
+        parameters:  tool.parameters,
+      },
+    }));
+  }
+}

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -29,23 +29,27 @@ dotenv.config();
  * Lista de variáveis que DEVEM existir para o bot funcionar.
  * O código não chega à linha de importação se alguma estiver ausente.
  */
-const REQUIRED = ['GEMINI_API_KEY'];
-
 /**
- * Valida que todas as variáveis obrigatórias estão presentes e não estão vazias.
- * Lança erro descritivo com todas as variáveis ausentes de uma só vez
- * (não falha na primeira e esconde o resto).
+ * Valida as variáveis obrigatórias com base no provider de IA ativo.
+ * Só exige a API Key do provider configurado em AI_PROVIDER.
  */
 function validateRequired() {
-  const missing = REQUIRED.filter(
-    (key) => !process.env[key] || process.env[key].trim() === '',
-  );
+  const missing = [];
+  const provider = process.env.AI_PROVIDER || 'gemini';
+
+  if (provider === 'gemini' || provider === undefined) {
+    if (!process.env.GEMINI_API_KEY?.trim()) missing.push('GEMINI_API_KEY');
+  }
+
+  if (provider === 'openai') {
+    if (!process.env.OPENAI_API_KEY?.trim()) missing.push('OPENAI_API_KEY');
+  }
 
   if (missing.length > 0) {
     throw new Error(
       `[Config] Variáveis de ambiente obrigatórias ausentes: ${missing.join(', ')}\n` +
       `Crie ou verifique o arquivo .env na raiz do projeto.\n` +
-      `Exemplo: GEMINI_API_KEY=sua_chave_aqui`,
+      `Provider ativo: AI_PROVIDER=${provider}`,
     );
   }
 }
@@ -62,7 +66,10 @@ validateRequired();
  * Acesse sempre via este objeto, nunca via process.env diretamente.
  *
  * @type {{
- *   GEMINI_API_KEY: string,
+ *   AI_PROVIDER: string,
+ *   AI_MODEL: string,
+ *   GEMINI_API_KEY: string | undefined,
+ *   OPENAI_API_KEY: string | undefined,
  *   TAVILY_API_KEY: string | undefined,
  *   OWNER_NUMBER: string | undefined,
  *   LOG_LEVEL: string,
@@ -72,8 +79,14 @@ validateRequired();
  * }}
  */
 export const env = Object.freeze({
-  // IA — obrigatório
-  GEMINI_API_KEY: process.env.GEMINI_API_KEY,
+  // Provider de IA — define qual adapter usar ('gemini' | 'openai')
+  AI_PROVIDER: process.env.AI_PROVIDER || 'gemini',
+  // Modelo específico — cada adapter usa seu padrão se não informado
+  AI_MODEL: process.env.AI_MODEL || undefined,
+
+  // API Keys — apenas a do provider ativo é obrigatória
+  GEMINI_API_KEY:  process.env.GEMINI_API_KEY  || undefined,
+  OPENAI_API_KEY:  process.env.OPENAI_API_KEY  || undefined,
 
   // Busca na internet — opcional (cai para Google Grounding se ausente)
   TAVILY_API_KEY: process.env.TAVILY_API_KEY || undefined,

--- a/src/infra/Bootstrap.js
+++ b/src/infra/Bootstrap.js
@@ -3,6 +3,7 @@ import { Container } from './Container.js';
 import { env } from '../config/env.js';
 
 import { GeminiAdapter } from '../adapters/ai/GeminiAdapter.js';
+import { OpenAIAdapter } from '../adapters/ai/OpenAIAdapter.js';
 import { TavilyAdapter } from '../adapters/search/TavilyAdapter.js';
 import { GoogleGroundingAdapter } from '../adapters/search/GoogleGroundingAdapter.js';
 import { GeminiTranscriberAdapter } from '../adapters/transcriber/GeminiTranscriberAdapter.js';
@@ -41,9 +42,19 @@ export function createContainer({ overrides = {} } = {}) {
   });
 
   // --- IA ---
-  // O GeminiAdapter recebe o SearchPort para executar o loop multi-turn de busca.
+  // O adapter é escolhido via env.AI_PROVIDER — zero alteração de código de domínio.
   container.register('aiPort', (c) => {
-    const adapter = new GeminiAdapter({ apiKey: env.GEMINI_API_KEY });
+    if (env.AI_PROVIDER === 'openai') {
+      return new OpenAIAdapter({
+        apiKey: env.OPENAI_API_KEY,
+        model:  env.AI_MODEL,
+      });
+    }
+    // Padrão: Gemini com loop multi-turn de busca
+    const adapter = new GeminiAdapter({
+      apiKey: env.GEMINI_API_KEY,
+      ...(env.AI_MODEL ? { models: [env.AI_MODEL] } : {}),
+    });
     adapter.setSearchPort(c.get('searchPort'));
     return adapter;
   });

--- a/tests/unit/adapters/AIAdapterContract.test.js
+++ b/tests/unit/adapters/AIAdapterContract.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Suite de contrato para AIPort.
+ * Roda o mesmo conjunto de testes para GeminiAdapter E OpenAIAdapter,
+ * garantindo paridade na interface.
+ */
+
+// ─── Mocks dos SDKs externos ──────────────────────────────────────────────────
+
+const geminiGenerate = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    candidates: [{ content: { parts: [{ text: 'ok' }] } }],
+    functionCalls: () => [],
+  })
+);
+
+const openaiCreate = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    choices: [{ message: { content: 'ok', tool_calls: [] } }],
+    usage: { prompt_tokens: 1, completion_tokens: 1 },
+  })
+);
+
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: class {
+    constructor() {
+      this.models = { generateContent: geminiGenerate };
+    }
+  },
+}));
+
+vi.mock('openai', () => ({
+  default: class OpenAI {
+    constructor() {
+      this.chat = { completions: { create: openaiCreate } };
+    }
+  },
+}));
+
+vi.mock('../../../src/config/lumaConfig.js', () => ({
+  LUMA_CONFIG: {
+    TECHNICAL: {
+      models: ['gemini-2.0-flash'],
+      generationConfig: { temperature: 1 },
+    },
+    TOOLS: [],
+  },
+}));
+
+const { GeminiAdapter } = await import('../../../src/adapters/ai/GeminiAdapter.js');
+const { OpenAIAdapter  } = await import('../../../src/adapters/ai/OpenAIAdapter.js');
+
+// ─── Função de contrato ───────────────────────────────────────────────────────
+
+function runContractTests(name, createAdapter) {
+  describe(`AIPort contract — ${name}`, () => {
+    let adapter;
+    beforeEach(() => {
+      vi.clearAllMocks();
+      adapter = createAdapter();
+    });
+
+    it('implementa generateContent() → { text, functionCalls }', async () => {
+      const result = await adapter.generateContent([], 'system prompt', []);
+      expect(result).toHaveProperty('text');
+      expect(result).toHaveProperty('functionCalls');
+      expect(Array.isArray(result.functionCalls)).toBe(true);
+    });
+
+    it('implementa getStats() → objeto não-nulo', () => {
+      const stats = adapter.getStats();
+      expect(typeof stats).toBe('object');
+      expect(stats).not.toBeNull();
+    });
+
+    it('generateContent aceita histórico vazio sem lançar erro', async () => {
+      await expect(adapter.generateContent([], 'system', [])).resolves.not.toThrow();
+    });
+
+    it('getStats retorna cópia — referências diferentes a cada chamada', () => {
+      expect(adapter.getStats()).not.toBe(adapter.getStats());
+    });
+  });
+}
+
+// ─── Executa o contrato para cada adapter ────────────────────────────────────
+
+runContractTests('GeminiAdapter', () =>
+  new GeminiAdapter({ apiKey: 'fake-gemini-key' })
+);
+
+runContractTests('OpenAIAdapter', () =>
+  new OpenAIAdapter({ apiKey: 'fake-openai-key', model: 'gpt-4o-mini' })
+);

--- a/tests/unit/adapters/OpenAIAdapter.test.js
+++ b/tests/unit/adapters/OpenAIAdapter.test.js
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.hoisted garante que create está disponível antes do vi.mock (ESM hoisting)
+const create = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    choices: [{ message: { content: 'resposta mock', tool_calls: [] } }],
+    usage: { prompt_tokens: 10, completion_tokens: 5 },
+  })
+);
+
+vi.mock('openai', () => ({
+  default: class OpenAI {
+    constructor() {
+      this.chat = { completions: { create } };
+    }
+  },
+}));
+
+const { OpenAIAdapter } = await import('../../../src/adapters/ai/OpenAIAdapter.js');
+
+function makeAdapter() {
+  return new OpenAIAdapter({ apiKey: 'sk-fake', model: 'gpt-4o-mini' });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('OpenAIAdapter — construtor', () => {
+  it('lança erro se apiKey não for fornecida', () => {
+    expect(() => new OpenAIAdapter({})).toThrow('apiKey');
+  });
+
+  it('cria instância com apiKey válida', () => {
+    expect(() => makeAdapter()).not.toThrow();
+  });
+});
+
+describe('OpenAIAdapter.generateContent', () => {
+  it('chama create com messages formatadas corretamente', async () => {
+    const adapter = makeAdapter();
+    const history = [
+      { role: 'user',  parts: [{ text: 'oi' }] },
+      { role: 'model', parts: [{ text: 'olá!' }] },
+    ];
+
+    await adapter.generateContent(history, 'Você é a Luma.');
+
+    const call = create.mock.calls[0][0];
+    expect(call.messages[0]).toEqual({ role: 'system',    content: 'Você é a Luma.' });
+    expect(call.messages[1]).toEqual({ role: 'user',      content: 'oi' });
+    expect(call.messages[2]).toEqual({ role: 'assistant', content: 'olá!' });
+  });
+
+  it('retorna { text, functionCalls } no formato interno', async () => {
+    const adapter = makeAdapter();
+    const result  = await adapter.generateContent([], 'system');
+
+    expect(result).toHaveProperty('text', 'resposta mock');
+    expect(Array.isArray(result.functionCalls)).toBe(true);
+  });
+
+  it('extrai tool_calls quando presentes', async () => {
+    create.mockResolvedValueOnce({
+      choices: [{
+        message: {
+          content: '',
+          tool_calls: [{
+            function: { name: 'tag_everyone', arguments: '{"target":"all"}' },
+          }],
+        },
+      }],
+      usage: { prompt_tokens: 5, completion_tokens: 2 },
+    });
+
+    const result = await makeAdapter().generateContent([], 'system');
+    expect(result.functionCalls).toHaveLength(1);
+    expect(result.functionCalls[0]).toEqual({ name: 'tag_everyone', args: { target: 'all' } });
+  });
+
+  it('inclui tools convertidas quando fornecidas', async () => {
+    const tools = [{ name: 'fn', description: 'desc', parameters: { type: 'object' } }];
+    await makeAdapter().generateContent([], 'system', tools);
+
+    const call = create.mock.calls[0][0];
+    expect(call.tools).toBeDefined();
+    expect(call.tools[0].type).toBe('function');
+    expect(call.tools[0].function.name).toBe('fn');
+  });
+
+  it('não inclui tools quando lista vazia', async () => {
+    await makeAdapter().generateContent([], 'system', []);
+    const call = create.mock.calls[0][0];
+    expect(call.tools).toBeUndefined();
+  });
+});
+
+describe('OpenAIAdapter.processMedia', () => {
+  it('envia prompt + imagem no formato image_url', async () => {
+    const media = [{ mimeType: 'image/jpeg', data: Buffer.from('fake') }];
+    await makeAdapter().processMedia('descreva', media);
+
+    const content = create.mock.calls[0][0].messages[0].content;
+    expect(content[0]).toEqual({ type: 'text', text: 'descreva' });
+    expect(content[1].type).toBe('image_url');
+    expect(content[1].image_url.url).toMatch(/^data:image\/jpeg;base64,/);
+  });
+
+  it('retorna string com a resposta', async () => {
+    const result = await makeAdapter().processMedia('prompt', []);
+    expect(typeof result).toBe('string');
+  });
+});
+
+describe('OpenAIAdapter.getStats', () => {
+  it('acumula calls e tokens após generateContent', async () => {
+    const adapter = makeAdapter();
+    await adapter.generateContent([], 'system');
+    const stats = adapter.getStats();
+    expect(stats.calls).toBe(1);
+    expect(stats.tokensIn).toBe(10);
+    expect(stats.tokensOut).toBe(5);
+  });
+
+  it('retorna cópia — mutação externa não afeta estado interno', () => {
+    const adapter = makeAdapter();
+    const stats   = adapter.getStats();
+    stats.calls   = 999;
+    expect(adapter.getStats().calls).toBe(0);
+  });
+});

--- a/tests/unit/infra/Bootstrap.test.js
+++ b/tests/unit/infra/Bootstrap.test.js
@@ -1,10 +1,15 @@
 import { describe, it, expect, vi } from 'vitest';
 
-// Mocks antes de importar Bootstrap
+// ─── Mocks de todos os adapters ──────────────────────────────────────────────
+
 vi.mock('../../../src/adapters/ai/GeminiAdapter.js', () => ({
-  GeminiAdapter: class {
+  GeminiAdapter: class GeminiAdapter {
     setSearchPort = vi.fn();
   },
+}));
+
+vi.mock('../../../src/adapters/ai/OpenAIAdapter.js', () => ({
+  OpenAIAdapter: class OpenAIAdapter {},
 }));
 
 vi.mock('../../../src/adapters/search/TavilyAdapter.js', () => ({
@@ -31,13 +36,18 @@ vi.mock('@google/genai', () => ({
 
 vi.mock('../../../src/config/env.js', () => ({
   env: {
+    AI_PROVIDER:    'gemini',
+    AI_MODEL:       undefined,
     GEMINI_API_KEY: 'fake-gemini-key',
+    OPENAI_API_KEY: undefined,
     TAVILY_API_KEY: undefined,
   },
 }));
 
 // Importa DEPOIS dos mocks
 const { createContainer } = await import('../../../src/infra/Bootstrap.js');
+const { GeminiAdapter }   = await import('../../../src/adapters/ai/GeminiAdapter.js');
+const { OpenAIAdapter }   = await import('../../../src/adapters/ai/OpenAIAdapter.js');
 
 describe('Bootstrap — createContainer', () => {
   it('retorna um Container', async () => {
@@ -48,11 +58,10 @@ describe('Bootstrap — createContainer', () => {
 
   it('registra os tokens esperados', () => {
     const c = createContainer();
-    const tokens = c.registeredTokens();
-    expect(tokens).toContain('storagePort');
-    expect(tokens).toContain('aiPort');
-    expect(tokens).toContain('searchPort');
-    expect(tokens).toContain('transcriberPort');
+    expect(c.registeredTokens()).toContain('storagePort');
+    expect(c.registeredTokens()).toContain('aiPort');
+    expect(c.registeredTokens()).toContain('searchPort');
+    expect(c.registeredTokens()).toContain('transcriberPort');
   });
 
   it('resolve storagePort sem erros', () => {
@@ -77,9 +86,7 @@ describe('Bootstrap — createContainer', () => {
 
   it('overrides substitui a factory de um token', () => {
     const mockStorage = { fake: true };
-    const c = createContainer({
-      overrides: { storagePort: () => mockStorage },
-    });
+    const c = createContainer({ overrides: { storagePort: () => mockStorage } });
     expect(c.get('storagePort')).toBe(mockStorage);
   });
 
@@ -87,5 +94,29 @@ describe('Bootstrap — createContainer', () => {
     const c = createContainer();
     expect(c.get('storagePort')).toBe(c.get('storagePort'));
     expect(c.get('searchPort')).toBe(c.get('searchPort'));
+  });
+});
+
+describe('Bootstrap — seleção de AI_PROVIDER', () => {
+  it('AI_PROVIDER=gemini resolve GeminiAdapter por padrão', () => {
+    const c      = createContainer();
+    const aiPort = c.get('aiPort');
+    expect(aiPort).toBeInstanceOf(GeminiAdapter);
+  });
+
+  it('AI_PROVIDER=openai resolve OpenAIAdapter via override', () => {
+    const c = createContainer({
+      overrides: {
+        aiPort: () => new OpenAIAdapter(),
+      },
+    });
+    const aiPort = c.get('aiPort');
+    expect(aiPort).toBeInstanceOf(OpenAIAdapter);
+  });
+
+  it('AI_PROVIDER=gemini chama setSearchPort no GeminiAdapter', () => {
+    const c      = createContainer();
+    const aiPort = c.get('aiPort');
+    expect(aiPort.setSearchPort).toHaveBeenCalledWith(c.get('searchPort'));
   });
 });


### PR DESCRIPTION
## Summary

- **OpenAIAdapter**: implementa `AIPort` completo — `generateContent` (mapeia histórico interno → Messages API, converte tools Gemini → OpenAI), `processMedia` (imagens via image_url), `getStats` (calls, tokensIn, tokensOut)
- **Bootstrap**: seleciona adapter via `env.AI_PROVIDER` — zero alteração em código de domínio para trocar provider
- **env.js**: validação condicional — exige `GEMINI_API_KEY` só se `AI_PROVIDER=gemini`, exige `OPENAI_API_KEY` só se `AI_PROVIDER=openai`; novos campos `AI_PROVIDER`, `AI_MODEL`, `OPENAI_API_KEY`

**Para usar OpenAI:**
```env
AI_PROVIDER=openai
OPENAI_API_KEY=sk-...
AI_MODEL=gpt-4o-mini  # opcional
```

## Test plan

- [x] 394 testes passando (25 suites)
- [x] `OpenAIAdapter.test.js` — construtor, generateContent (histórico, tool_calls, tools), processMedia, getStats
- [x] `AIAdapterContract.test.js` — mesma suite de contrato roda para GeminiAdapter E OpenAIAdapter
- [x] `Bootstrap.test.js` — `AI_PROVIDER=gemini` → GeminiAdapter + setSearchPort; OpenAIAdapter via override

🤖 Generated with [Claude Code](https://claude.com/claude-code)